### PR TITLE
Update lasermpnn dep

### DIFF
--- a/NISE_LASErMPNN.ipynb
+++ b/NISE_LASErMPNN.ipynb
@@ -1,28 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "gpuType": "A100",
-      "authorship_tag": "ABX9TyNQajT6vsVn6b4tVLiQC7jn",
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "accelerator": "GPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/polizzilab/NISE/blob/main/NISE_LASErMPNN.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -48,6 +30,9 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "8o7gsUa7pKxE"
+      },
       "source": [
         "### Preliminary Setup:\n",
         "\n",
@@ -70,13 +55,13 @@
         "\n",
         "\n",
         "This will make the files in this folder accessible in your Google Colab notebook even though they are not copied to your Google Drive and will not take up space (this is good since they are big files)"
-      ],
-      "metadata": {
-        "id": "8o7gsUa7pKxE"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "VlPP6BLILBNa"
+      },
       "source": [
         "___\n",
         "\n",
@@ -88,13 +73,41 @@
         "\n",
         "To proceed, run the first cell and wait for the notebook to 'crash' this will install dependencies into the Colab runtime. Once the notebook crashes, the runtime has been restarted with the new dependencies and you can then hit the `Run all` button to proceed and test the notebook.\n",
         "___"
-      ],
-      "metadata": {
-        "id": "VlPP6BLILBNa"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "cellView": "form",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ZyBachQD0Zjc",
+        "outputId": "c9b39f7b-3df3-4505-a958-7277b0698e0f"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Cloning into 'NISE'...\n",
+            "remote: Enumerating objects: 23, done.\u001b[K\n",
+            "remote: Counting objects: 100% (23/23), done.\u001b[K\n",
+            "remote: Compressing objects: 100% (22/22), done.\u001b[K\n",
+            "remote: Total 23 (delta 3), reused 11 (delta 0), pack-reused 0 (from 0)\u001b[K\n",
+            "Receiving objects: 100% (23/23), 26.02 MiB | 45.08 MiB/s, done.\n",
+            "Resolving deltas: 100% (3/3), done.\n",
+            "Submodule 'LASErMPNN' (https://github.com/polizzilab/LASErMPNN.git) registered for path 'LASErMPNN'\n",
+            "Submodule 'LigandMPNN' (https://github.com/dauparas/LigandMPNN.git) registered for path 'LigandMPNN'\n",
+            "Cloning into '/content/NISE/LASErMPNN'...\n",
+            "Cloning into '/content/NISE/LigandMPNN'...\n",
+            "Submodule path 'LASErMPNN': checked out '0be50b3009b971f6b1d8a93121bc545ba7327a0d'\n",
+            "Submodule path 'LigandMPNN': checked out '26ec57ac976ade5379920dbd43c7f97a91cf82de'\n",
+            "Dependencies successfully installed!\n"
+          ]
+        }
+      ],
       "source": [
         "\n",
         "import os\n",
@@ -119,41 +132,28 @@
         "except:\n",
         "  !pip install prody seaborn tqdm rdkit py3Dmol openbabel-wheel freesasa\n",
         "  os.kill(os.getpid(), 9)\n"
-      ],
-      "metadata": {
-        "id": "ZyBachQD0Zjc",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "c9b39f7b-3df3-4505-a958-7277b0698e0f",
-        "cellView": "form"
-      },
-      "execution_count": 1,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Cloning into 'NISE'...\n",
-            "remote: Enumerating objects: 23, done.\u001b[K\n",
-            "remote: Counting objects: 100% (23/23), done.\u001b[K\n",
-            "remote: Compressing objects: 100% (22/22), done.\u001b[K\n",
-            "remote: Total 23 (delta 3), reused 11 (delta 0), pack-reused 0 (from 0)\u001b[K\n",
-            "Receiving objects: 100% (23/23), 26.02 MiB | 45.08 MiB/s, done.\n",
-            "Resolving deltas: 100% (3/3), done.\n",
-            "Submodule 'LASErMPNN' (https://github.com/polizzilab/LASErMPNN.git) registered for path 'LASErMPNN'\n",
-            "Submodule 'LigandMPNN' (https://github.com/dauparas/LigandMPNN.git) registered for path 'LigandMPNN'\n",
-            "Cloning into '/content/NISE/LASErMPNN'...\n",
-            "Cloning into '/content/NISE/LigandMPNN'...\n",
-            "Submodule path 'LASErMPNN': checked out '0be50b3009b971f6b1d8a93121bc545ba7327a0d'\n",
-            "Submodule path 'LigandMPNN': checked out '26ec57ac976ade5379920dbd43c7f97a91cf82de'\n",
-            "Dependencies successfully installed!\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 2,
+      "metadata": {
+        "cellView": "form",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "CieIpUsjKjQs",
+        "outputId": "4b88e58c-27d0-484f-e812-c83cf04cd58d"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Mounted at /content/drive/\n"
+          ]
+        }
+      ],
       "source": [
         "# @title ### Connect to pre-configured Boltz-2x weights through your Google Drive.\n",
         "from pathlib import Path\n",
@@ -163,28 +163,31 @@
         "if not Path('/content/drive/MyDrive/boltz').exists():\n",
         "    print('You probably didn\\'t follow the steps depicted in the images above. You must link the boltz directory linked at the top of the previous cell into your google drive so it can be accessed in this Colab notebook. Once you have done this, hit runtime -> Disconnect and delete runtime, then hit runall again.')\n",
         "    raise NotImplementedError"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "CieIpUsjKjQs",
-        "outputId": "4b88e58c-27d0-484f-e812-c83cf04cd58d",
-        "cellView": "form"
-      },
-      "execution_count": 2,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Mounted at /content/drive/\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ZLWGKyDHAjO_",
+        "outputId": "8b472731-b4ea-44fe-8de8-7e265436fcd1"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Venv python: .venv/bin/python\n",
+            "Done. Use this Python: .venv/bin/python\n",
+            "2.8.0+cu128\n",
+            "True\n"
+          ]
+        }
+      ],
       "source": [
         "# @title ### Install LASErMPNN and Boltz dependencies as separate python installation. (~2 mins)\n",
         "# @markdown LASErMPNN and Boltz-2 are being installed into a virtual environment separate from the Colab runtime.\n",
@@ -219,6 +222,7 @@
         "        \"h5py\",\n",
         "        \"pytest\",\n",
         "        \"prody\",\n",
+        "        \"pydssp\",\n",
         "        \"matplotlib\",\n",
         "        \"rdkit-to-params\",\n",
         "        \"seaborn\",\n",
@@ -277,31 +281,29 @@
         "print(\"Done. Use this Python:\", venv_py)\n",
         "\n",
         "!./.venv/bin/python -c \"import torch, torch_scatter; print(torch.__version__); print(torch.cuda.is_available())\""
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "ZLWGKyDHAjO_",
-        "outputId": "8b472731-b4ea-44fe-8de8-7e265436fcd1",
-        "cellView": "form"
-      },
-      "execution_count": 3,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Venv python: .venv/bin/python\n",
-            "Done. Use this Python: .venv/bin/python\n",
-            "2.8.0+cu128\n",
-            "True\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "cellView": "form",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "vAM-8QOWjhHM",
+        "outputId": "3496493f-64e5-4dec-f6b1-6fcf0c511a09"
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "@> ProDy is configured: verbosity='none'\n",
+            "INFO:.prody:ProDy is configured: verbosity='none'\n"
+          ]
+        }
+      ],
       "source": [
         "# @title ### Configure packages\n",
         "import sys\n",
@@ -318,51 +320,32 @@
         "pr.confProDy(verbosity='none')\n",
         "logging.basicConfig(level=logging.DEBUG, filename='app.log', force=True)\n",
         "logging.getLogger(\"prody\").setLevel(logging.WARNING)"
-      ],
-      "metadata": {
-        "id": "vAM-8QOWjhHM",
-        "cellView": "form",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "3496493f-64e5-4dec-f6b1-6fcf0c511a09"
-      },
-      "execution_count": 4,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "@> ProDy is configured: verbosity='none'\n",
-            "INFO:.prody:ProDy is configured: verbosity='none'\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "# 1) Upload input structure"
-      ],
       "metadata": {
         "id": "jKQdJVrLAnmZ"
-      }
+      },
+      "source": [
+        "# 1) Upload input structure"
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": 13,
       "metadata": {
-        "id": "edyhKtZye_w1",
         "cellView": "form",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "edyhKtZye_w1",
         "outputId": "29bde33e-613e-49a1-cfa3-2c46f8349849"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Deleting previous NISE trajectory.\n"
           ]
@@ -437,43 +420,18 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "# @title ### Visualize input structure\n",
-        "import py3Dmol\n",
-        "\n",
-        "view = py3Dmol.view(width=1000)\n",
-        "view.addModel(open('./nise_trajectory/input_backbones/input.pdb', 'r').read(), 'pdb', keepH=True)\n",
-        "\n",
-        "view.setBackgroundColor('black')\n",
-        "view.setStyle({}, {})  # clear default\n",
-        "\n",
-        "# Chain A: cartoon + sticks with green carbons, other elements by element color\n",
-        "view.setStyle({'chain': 'A'}, {\n",
-        "    'cartoon': {'colorscheme': 'greenCarbon'},\n",
-        "    'stick': {'colorscheme': 'greenCarbon'}\n",
-        "})\n",
-        "\n",
-        "# Chain B: sticks with cyan carbons, other elements by element color\n",
-        "view.setStyle({'chain': 'B'}, {\n",
-        "    'stick': {'colorscheme': 'cyanCarbon'}\n",
-        "})\n",
-        "\n",
-        "view.zoomTo()\n",
-        "view.show()"
-      ],
+      "execution_count": 14,
       "metadata": {
+        "cellView": "form",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 497
         },
-        "cellView": "form",
         "id": "qlgMTlviwCW-",
         "outputId": "c80b553e-4b92-4315-ad8b-e35271d25e7c"
       },
-      "execution_count": 14,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
             "application/3dmoljs_load.v0": "<div id=\"3dmolviewer_17690125233949301\"  style=\"position: relative; width: 1000px; height: 480px;\">\n        <p id=\"3dmolwarning_17690125233949301\" style=\"background-color:#ffcccc;color:black\">3Dmol.js failed to load for some reason.  Please check your browser console for error messages.<br></p>\n        </div>\n<script>\n\nvar loadScriptAsync = function(uri){\n  return new Promise((resolve, reject) => {\n    //this is to ignore the existence of requirejs amd\n    var savedexports, savedmodule;\n    if (typeof exports !== 'undefined') savedexports = exports;\n    else exports = {}\n    if (typeof module !== 'undefined') savedmodule = module;\n    else module = {}\n\n    var tag = document.createElement('script');\n    tag.src = uri;\n    tag.async = true;\n    tag.onload = () => {\n        exports = savedexports;\n        module = savedmodule;\n        resolve();\n    };\n  var firstScriptTag = document.getElementsByTagName('script')[0];\n  firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);\n});\n};\n\nif(typeof $3Dmolpromise === 'undefined') {\n$3Dmolpromise = null;\n  $3Dmolpromise = loadScriptAsync('https://cdn.jsdelivr.net/npm/3dmol@2.5.3/build/3Dmol-min.js');\n}\n\nvar viewer_17690125233949301 = null;\nvar warn = document.getElementById(\"3dmolwarning_17690125233949301\");\nif(warn) {\n    warn.parentNode.removeChild(warn);\n}\n$3Dmolpromise.then(function() {\nviewer_17690125233949301 = $3Dmol.createViewer(document.getElementById(\"3dmolviewer_17690125233949301\"),{backgroundColor:\"white\"});\nviewer_17690125233949301.zoomTo();\n\tviewer_17690125233949301.addModel(\"REMARK AtomGroup seq_0980_model_0_rank_01 Selection 'protein' + COC1=CC=C(N2C3=C(C(C(N)=O)=N2)CCN(C4=CC=C(N5CCCCC5=O)C=C4)C3=O)C=C1\\nATOM      1  N   ALA A   1       1.952   8.023  22.786  1.00 82.39           N  \\nATOM      2  CA  ALA A   1       1.363   7.622  21.504  1.00 82.39           C  \\nATOM      3  C   ALA A   1       2.422   7.665  20.406  1.00 82.39           C  \\nATOM      4  O   ALA A   1       3.318   8.506  20.449  1.00 82.39           O  \\nATOM      5  CB  ALA A   1       0.199   8.538  21.136  1.00 82.39           C  \\nATOM      6  N   PRO A   2       2.331   6.773  19.447  1.00 96.35           N  \\nATOM      7  CA  PRO A   2       3.298   6.805  18.347  1.00 96.35           C  \\nATOM      8  C   PRO A   2       3.221   8.117  17.578  1.00 96.35           C  \\nATOM      9  O   PRO A   2       2.154   8.729  17.482  1.00 96.35           O  \\nATOM     10  CB  PRO A   2       2.887   5.633  17.455  1.00 96.35           C  \\nATOM     11  CG  PRO A   2       2.073   4.736  18.329  1.00 96.35           C  \\nATOM     12  CD  PRO A   2       1.378   5.638  19.305  1.00 96.35           C  \\nATOM     13  N   SER A   3       4.347   8.527  17.026  1.00 97.61           N  \\nATOM     14  CA  SER A   3       4.378   9.699  16.167  1.00 97.61           C  \\nATOM     15  C   SER A   3       3.584   9.436  14.891  1.00 97.61           C  \\nATOM     16  O   SER A   3       3.301   8.283  14.540  1.00 97.61           O  \\nATOM     17  CB  SER A   3       5.817  10.058  15.812  1.00 97.61           C  \\nATOM     18  OG  SER A   3       6.388   9.052  14.987  1.00 97.61           O  \\nATOM     19  N   LEU A   4       3.239  10.514  14.199  1.00 98.36           N  \\nATOM     20  CA  LEU A   4       2.549  10.349  12.924  1.00 98.36           C  \\nATOM     21  C   LEU A   4       3.383   9.516  11.958  1.00 98.36           C  \\nATOM     22  O   LEU A   4       2.853   8.656  11.245  1.00 98.36           O  \\nATOM     23  CB  LEU A   4       2.223  11.710  12.314  1.00 98.36           C  \\nATOM     24  CG  LEU A   4       1.538  11.697  10.952  1.00 98.36           C  \\nATOM     25  CD1 LEU A   4       0.258  10.873  10.977  1.00 98.36           C  \\nATOM     26  CD2 LEU A   4       1.256  13.126  10.493  1.00 98.36           C  \\nATOM     27  N   GLU A   5       4.685   9.751  11.929  1.00 98.16           N  \\nATOM     28  CA  GLU A   5       5.551   8.971  11.056  1.00 98.16           C  \\nATOM     29  C   GLU A   5       5.474   7.485  11.391  1.00 98.16           C  \\nATOM     30  O   GLU A   5       5.366   6.639  10.497  1.00 98.16           O  \\nATOM     31  CB  GLU A   5       6.994   9.463  11.162  1.00 98.16           C  \\nATOM     32  CG  GLU A   5       7.994   8.623  10.391  1.00 98.16           C  \\nATOM     33  CD  GLU A   5       9.419   9.139  10.496  1.00 98.16           C  \\nATOM     34  OE1 GLU A   5       9.603  10.330  10.822  1.00 98.16           O  \\nATOM     35  OE2 GLU A   5      10.352   8.354  10.240  1.00 98.16           O  \\nATOM     36  N   GLU A   6       5.537   7.147  12.674  1.00 98.12           N  \\nATOM     37  CA  GLU A   6       5.469   5.748  13.085  1.00 98.12           C  \\nATOM     38  C   GLU A   6       4.121   5.129  12.738  1.00 98.12           C  \\nATOM     39  O   GLU A   6       4.049   3.961  12.332  1.00 98.12           O  \\nATOM     40  CB  GLU A   6       5.741   5.625  14.581  1.00 98.12           C  \\nATOM     41  CG  GLU A   6       7.178   5.935  14.965  1.00 98.12           C  \\nATOM     42  CD  GLU A   6       7.380   6.069  16.461  1.00 98.12           C  \\nATOM     43  OE1 GLU A   6       6.464   6.546  17.162  1.00 98.12           O  \\nATOM     44  OE2 GLU A   6       8.465   5.694  16.939  1.00 98.12           O  \\nATOM     45  N   GLN A   7       3.045   5.904  12.908  1.00 98.54           N  \\nATOM     46  CA  GLN A   7       1.722   5.403  12.551  1.00 98.54           C  \\nATOM     47  C   GLN A   7       1.625   5.127  11.058  1.00 98.54           C  \\nATOM     48  O   GLN A   7       1.018   4.133  10.639  1.00 98.54           O  \\nATOM     49  CB  GLN A   7       0.642   6.400  12.964  1.00 98.54           C  \\nATOM     50  CG  GLN A   7       0.535   6.626  14.457  1.00 98.54           C  \\nATOM     51  CD  GLN A   7      -0.511   7.664  14.791  1.00 98.54           C  \\nATOM     52  OE1 GLN A   7      -1.659   7.570  14.346  1.00 98.54           O  \\nATOM     53  NE2 GLN A   7      -0.127   8.669  15.569  1.00 98.54           N  \\nATOM     54  N   CYS A   8       2.199   5.997  10.235  1.00 98.90           N  \\nATOM     55  CA  CYS A   8       2.163   5.807   8.787  1.00 98.90           C  \\nATOM     56  C   CYS A   8       2.970   4.585   8.367  1.00 98.90           C  \\nATOM     57  O   CYS A   8       2.553   3.831   7.479  1.00 98.90           O  \\nATOM     58  CB  CYS A   8       2.674   7.058   8.074  1.00 98.90           C  \\nATOM     59  SG  CYS A   8       1.593   8.492   8.274  1.00 98.90           S  \\nATOM     60  N   ILE A   9       4.122   4.384   8.984  1.00 98.71           N  \\nATOM     61  CA  ILE A   9       4.926   3.208   8.677  1.00 98.71           C  \\nATOM     62  C   ILE A   9       4.155   1.939   9.028  1.00 98.71           C  \\nATOM     63  O   ILE A   9       4.094   0.990   8.239  1.00 98.71           O  \\nATOM     64  CB  ILE A   9       6.277   3.259   9.416  1.00 98.71           C  \\nATOM     65  CG1 ILE A   9       7.150   4.375   8.843  1.00 98.71           C  \\nATOM     66  CG2 ILE A   9       6.985   1.915   9.328  1.00 98.71           C  \\nATOM     67  CD1 ILE A   9       8.368   4.693   9.688  1.00 98.71           C  \\nATOM     68  N   ALA A  10       3.559   1.916  10.209  1.00 98.67           N  \\nATOM     69  CA  ALA A  10       2.819   0.735  10.639  1.00 98.67           C  \\nATOM     70  C   ALA A  10       1.642   0.458   9.715  1.00 98.67           C  \\nATOM     71  O   ALA A  10       1.410  -0.690   9.317  1.00 98.67           O  \\nATOM     72  CB  ALA A  10       2.342   0.901  12.079  1.00 98.67           C  \\nATOM     73  N   LEU A  11       0.885   1.495   9.381  1.00 98.94           N  \\nATOM     74  CA  LEU A  11      -0.266   1.311   8.506  1.00 98.94           C  \\nATOM     75  C   LEU A  11       0.170   0.839   7.125  1.00 98.94           C  \\nATOM     76  O   LEU A  11      -0.470  -0.030   6.520  1.00 98.94           O  \\nATOM     77  CB  LEU A  11      -1.075   2.602   8.396  1.00 98.94           C  \\nATOM     78  CG  LEU A  11      -2.308   2.515   7.494  1.00 98.94           C  \\nATOM     79  CD1 LEU A  11      -3.309   1.511   8.040  1.00 98.94           C  \\nATOM     80  CD2 LEU A  11      -2.945   3.889   7.330  1.00 98.94           C  \\nATOM     81  N   GLY A  12       1.253   1.401   6.617  1.00 98.90           N  \\nATOM     82  CA  GLY A  12       1.739   0.986   5.311  1.00 98.90           C  \\nATOM     83  C   GLY A  12       2.132  -0.479   5.284  1.00 98.90           C  \\nATOM     84  O   GLY A  12       1.830  -1.194   4.321  1.00 98.90           O  \\nATOM     85  N   ARG A  13       2.788  -0.929   6.326  1.00 98.62           N  \\nATOM     86  CA  ARG A  13       3.175  -2.333   6.395  1.00 98.62           C  \\nATOM     87  C   ARG A  13       1.957  -3.234   6.532  1.00 98.62           C  \\nATOM     88  O   ARG A  13       1.902  -4.313   5.930  1.00 98.62           O  \\nATOM     89  CB  ARG A  13       4.155  -2.552   7.541  1.00 98.62           C  \\nATOM     90  CG  ARG A  13       5.516  -1.924   7.255  1.00 98.62           C  \\nATOM     91  CD  ARG A  13       6.466  -2.055   8.424  1.00 98.62           C  \\nATOM     92  NE  ARG A  13       7.774  -1.506   8.090  1.00 98.62           N  \\nATOM     93  CZ  ARG A  13       8.692  -1.144   8.975  1.00 98.62           C  \\nATOM     94  NH1 ARG A  13       8.462  -1.259  10.279  1.00 98.62           N  \\nATOM     95  NH2 ARG A  13       9.849  -0.657   8.550  1.00 98.62           N  \\nATOM     96  N   GLU A  14       0.974  -2.802   7.313  1.00 98.83           N  \\nATOM     97  CA  GLU A  14      -0.264  -3.560   7.440  1.00 98.83           C  \\nATOM     98  C   GLU A  14      -0.992  -3.647   6.107  1.00 98.83           C  \\nATOM     99  O   GLU A  14      -1.559  -4.689   5.764  1.00 98.83           O  \\nATOM    100  CB  GLU A  14      -1.181  -2.925   8.483  1.00 98.83           C  \\nATOM    101  CG  GLU A  14      -0.679  -3.042   9.909  1.00 98.83           C  \\nATOM    102  CD  GLU A  14      -1.527  -2.247  10.892  1.00 98.83           C  \\nATOM    103  OE1 GLU A  14      -2.651  -1.834  10.529  1.00 98.83           O  \\nATOM    104  OE2 GLU A  14      -1.067  -2.037  12.027  1.00 98.83           O  \\nATOM    105  N   PHE A  15      -0.996  -2.552   5.366  1.00 98.95           N  \\nATOM    106  CA  PHE A  15      -1.667  -2.532   4.070  1.00 98.95           C  \\nATOM    107  C   PHE A  15      -1.021  -3.522   3.107  1.00 98.95           C  \\nATOM    108  O   PHE A  15      -1.724  -4.257   2.401  1.00 98.95           O  \\nATOM    109  CB  PHE A  15      -1.637  -1.118   3.488  1.00 98.95           C  \\nATOM    110  CG  PHE A  15      -2.316  -1.014   2.150  1.00 98.95           C  \\nATOM    111  CD1 PHE A  15      -3.692  -0.858   2.074  1.00 98.95           C  \\nATOM    112  CD2 PHE A  15      -1.583  -1.065   0.977  1.00 98.95           C  \\nATOM    113  CE1 PHE A  15      -4.329  -0.762   0.848  1.00 98.95           C  \\nATOM    114  CE2 PHE A  15      -2.216  -0.971  -0.252  1.00 98.95           C  \\nATOM    115  CZ  PHE A  15      -3.585  -0.820  -0.313  1.00 98.95           C  \\nATOM    116  N   VAL A  16       0.303  -3.548   3.059  1.00 98.72           N  \\nATOM    117  CA  VAL A  16       0.994  -4.485   2.183  1.00 98.72           C  \\nATOM    118  C   VAL A  16       0.667  -5.923   2.580  1.00 98.72           C  \\nATOM    119  O   VAL A  16       0.394  -6.772   1.720  1.00 98.72           O  \\nATOM    120  CB  VAL A  16       2.516  -4.231   2.202  1.00 98.72           C  \\nATOM    121  CG1 VAL A  16       3.259  -5.365   1.504  1.00 98.72           C  \\nATOM    122  CG2 VAL A  16       2.821  -2.893   1.531  1.00 98.72           C  \\nATOM    123  N   ALA A  17       0.676  -6.206   3.871  1.00 98.90           N  \\nATOM    124  CA  ALA A  17       0.353  -7.551   4.333  1.00 98.90           C  \\nATOM    125  C   ALA A  17      -1.062  -7.941   3.936  1.00 98.90           C  \\nATOM    126  O   ALA A  17      -1.304  -9.069   3.487  1.00 98.90           O  \\nATOM    127  CB  ALA A  17       0.535  -7.652   5.846  1.00 98.90           C  \\nATOM    128  N   ALA A  18      -2.002  -7.023   4.101  1.00 98.97           N  \\nATOM    129  CA  ALA A  18      -3.387  -7.307   3.743  1.00 98.97           C  \\nATOM    130  C   ALA A  18      -3.529  -7.532   2.242  1.00 98.97           C  \\nATOM    131  O   ALA A  18      -4.257  -8.433   1.808  1.00 98.97           O  \\nATOM    132  CB  ALA A  18      -4.296  -6.171   4.206  1.00 98.97           C  \\nATOM    133  N   ALA A  19      -2.849  -6.718   1.447  1.00 98.88           N  \\nATOM    134  CA  ALA A  19      -2.911  -6.877  -0.002  1.00 98.88           C  \\nATOM    135  C   ALA A  19      -2.355  -8.232  -0.421  1.00 98.88           C  \\nATOM    136  O   ALA A  19      -2.923  -8.907  -1.289  1.00 98.88           O  \\nATOM    137  CB  ALA A  19      -2.144  -5.751  -0.691  1.00 98.88           C  \\nATOM    138  N   ASN A  20      -1.249  -8.638   0.180  1.00 98.84           N  \\nATOM    139  CA  ASN A  20      -0.648  -9.925  -0.146  1.00 98.84           C  \\nATOM    140  C   ASN A  20      -1.502 -11.106   0.297  1.00 98.84           C  \\nATOM    141  O   ASN A  20      -1.332 -12.219  -0.214  1.00 98.84           O  \\nATOM    142  CB  ASN A  20       0.746 -10.030   0.473  1.00 98.84           C  \\nATOM    143  CG  ASN A  20       1.768  -9.181  -0.258  1.00 98.84           C  \\nATOM    144  OD1 ASN A  20       1.601  -8.851  -1.428  1.00 98.84           O  \\nATOM    145  ND2 ASN A  20       2.850  -8.836   0.434  1.00 98.84           N  \\nATOM    146  N   ALA A  21      -2.403 -10.870   1.235  1.00 98.82           N  \\nATOM    147  CA  ALA A  21      -3.324 -11.901   1.691  1.00 98.82           C  \\nATOM    148  C   ALA A  21      -4.675 -11.839   0.995  1.00 98.82           C  \\nATOM    149  O   ALA A  21      -5.532 -12.691   1.253  1.00 98.82           O  \\nATOM    150  CB  ALA A  21      -3.520 -11.798   3.198  1.00 98.82           C  \\nATOM    151  N   GLY A  22      -4.887 -10.845   0.155  1.00 98.75           N  \\nATOM    152  CA  GLY A  22      -6.179 -10.667  -0.487  1.00 98.75           C  \\nATOM    153  C   GLY A  22      -7.282 -10.282   0.478  1.00 98.75           C  \\nATOM    154  O   GLY A  22      -8.457 -10.546   0.205  1.00 98.75           O  \\nATOM    155  N   ASP A  23      -6.927  -9.650   1.584  1.00 98.95           N  \\nATOM    156  CA  ASP A  23      -7.886  -9.312   2.633  1.00 98.95           C  \\nATOM    157  C   ASP A  23      -8.538  -7.977   2.294  1.00 98.95           C  \\nATOM    158  O   ASP A  23      -8.060  -6.910   2.690  1.00 98.95           O  \\nATOM    159  CB  ASP A  23      -7.185  -9.271   3.989  1.00 98.95           C  \\nATOM    160  CG  ASP A  23      -8.152  -9.140   5.151  1.00 98.95           C  \\nATOM    161  OD1 ASP A  23      -9.319  -8.751   4.937  1.00 98.95           O  \\nATOM    162  OD2 ASP A  23      -7.728  -9.431   6.291  1.00 98.95           O  \\nATOM    163  N   VAL A  24      -9.632  -8.050   1.568  1.00 98.23           N  \\nATOM    164  CA  VAL A  24     -10.288  -6.853   1.053  1.00 98.23           C  \\nATOM    165  C   VAL A  24     -10.800  -5.969   2.185  1.00 98.23           C  \\nATOM    166  O   VAL A  24     -10.659  -4.741   2.136  1.00 98.23           O  \\nATOM    167  CB  VAL A  24     -11.428  -7.242   0.092  1.00 98.23           C  \\nATOM    168  CG1 VAL A  24     -12.356  -6.068  -0.175  1.00 98.23           C  \\nATOM    169  CG2 VAL A  24     -10.841  -7.778  -1.211  1.00 98.23           C  \\nATOM    170  N   GLU A  25     -11.398  -6.572   3.204  1.00 98.74           N  \\nATOM    171  CA  GLU A  25     -11.971  -5.769   4.278  1.00 98.74           C  \\nATOM    172  C   GLU A  25     -10.885  -5.014   5.039  1.00 98.74           C  \\nATOM    173  O   GLU A  25     -11.068  -3.846   5.397  1.00 98.74           O  \\nATOM    174  CB  GLU A  25     -12.785  -6.641   5.224  1.00 98.74           C  \\nATOM    175  CG  GLU A  25     -13.479  -5.857   6.335  1.00 98.74           C  \\nATOM    176  CD  GLU A  25     -14.394  -4.768   5.808  1.00 98.74           C  \\nATOM    177  OE1 GLU A  25     -14.989  -4.944   4.728  1.00 98.74           O  \\nATOM    178  OE2 GLU A  25     -14.524  -3.724   6.490  1.00 98.74           O  \\nATOM    179  N   ALA A  26      -9.759  -5.669   5.286  1.00 98.96           N  \\nATOM    180  CA  ALA A  26      -8.662  -4.995   5.974  1.00 98.96           C  \\nATOM    181  C   ALA A  26      -8.151  -3.821   5.145  1.00 98.96           C  \\nATOM    182  O   ALA A  26      -7.929  -2.731   5.676  1.00 98.96           O  \\nATOM    183  CB  ALA A  26      -7.529  -5.972   6.272  1.00 98.96           C  \\nATOM    184  N   MET A  27      -7.960  -4.034   3.850  1.00 98.95           N  \\nATOM    185  CA  MET A  27      -7.494  -2.955   2.984  1.00 98.95           C  \\nATOM    186  C   MET A  27      -8.481  -1.801   2.966  1.00 98.95           C  \\nATOM    187  O   MET A  27      -8.088  -0.635   3.065  1.00 98.95           O  \\nATOM    188  CB  MET A  27      -7.275  -3.460   1.558  1.00 98.95           C  \\nATOM    189  CG  MET A  27      -6.046  -4.322   1.387  1.00 98.95           C  \\nATOM    190  SD  MET A  27      -5.772  -4.726  -0.351  1.00 98.95           S  \\nATOM    191  CE  MET A  27      -6.974  -6.033  -0.593  1.00 98.95           C  \\nATOM    192  N   ARG A  28      -9.757  -2.131   2.831  1.00 98.85           N  \\nATOM    193  CA  ARG A  28     -10.780  -1.092   2.773  1.00 98.85           C  \\nATOM    194  C   ARG A  28     -10.761  -0.218   4.025  1.00 98.85           C  \\nATOM    195  O   ARG A  28     -10.931   0.996   3.941  1.00 98.85           O  \\nATOM    196  CB  ARG A  28     -12.156  -1.730   2.565  1.00 98.85           C  \\nATOM    197  CG  ARG A  28     -13.290  -0.730   2.397  1.00 98.85           C  \\nATOM    198  CD  ARG A  28     -14.523  -1.399   1.792  1.00 98.85           C  \\nATOM    199  NE  ARG A  28     -14.851  -2.640   2.478  1.00 98.85           N  \\nATOM    200  CZ  ARG A  28     -14.999  -3.821   1.874  1.00 98.85           C  \\nATOM    201  NH1 ARG A  28     -14.859  -3.934   0.562  1.00 98.85           N  \\nATOM    202  NH2 ARG A  28     -15.290  -4.889   2.593  1.00 98.85           N  \\nATOM    203  N   SER A  29     -10.533  -0.831   5.178  1.00 98.72           N  \\nATOM    204  CA  SER A  29     -10.533  -0.095   6.436  1.00 98.72           C  \\nATOM    205  C   SER A  29      -9.375   0.894   6.534  1.00 98.72           C  \\nATOM    206  O   SER A  29      -9.432   1.829   7.334  1.00 98.72           O  \\nATOM    207  CB  SER A  29     -10.481  -1.062   7.618  1.00 98.72           C  \\nATOM    208  OG  SER A  29      -9.188  -1.614   7.778  1.00 98.72           O  \\nATOM    209  N   MET A  30      -8.324   0.691   5.751  1.00 98.97           N  \\nATOM    210  CA  MET A  30      -7.129   1.523   5.805  1.00 98.97           C  \\nATOM    211  C   MET A  30      -7.165   2.670   4.815  1.00 98.97           C  \\nATOM    212  O   MET A  30      -6.332   3.582   4.898  1.00 98.97           O  \\nATOM    213  CB  MET A  30      -5.888   0.678   5.523  1.00 98.97           C  \\nATOM    214  CG  MET A  30      -5.689  -0.476   6.481  1.00 98.97           C  \\nATOM    215  SD  MET A  30      -4.430  -1.616   5.873  1.00 98.97           S  \\nATOM    216  CE  MET A  30      -4.626  -2.959   7.043  1.00 98.97           C  \\nATOM    217  N   LEU A  31      -8.091   2.645   3.875  1.00 98.98           N  \\nATOM    218  CA  LEU A  31      -8.158   3.638   2.817  1.00 98.98           C  \\nATOM    219  C   LEU A  31      -9.155   4.728   3.174  1.00 98.98           C  \\nATOM    220  O   LEU A  31     -10.243   4.448   3.674  1.00 98.98           O  \\nATOM    221  CB  LEU A  31      -8.563   2.991   1.491  1.00 98.98           C  \\nATOM    222  CG  LEU A  31      -7.562   2.009   0.889  1.00 98.98           C  \\nATOM    223  CD1 LEU A  31      -8.201   1.226  -0.248  1.00 98.98           C  \\nATOM    224  CD2 LEU A  31      -6.321   2.745   0.407  1.00 98.98           C  \\nATOM    225  N   ALA A  32      -8.778   5.966   2.891  1.00 98.91           N  \\nATOM    226  CA  ALA A  32      -9.711   7.075   3.011  1.00 98.91           C  \\nATOM    227  C   ALA A  32     -10.866   6.869   2.035  1.00 98.91           C  \\nATOM    228  O   ALA A  32     -10.699   6.226   0.998  1.00 98.91           O  \\nATOM    229  CB  ALA A  32      -9.006   8.396   2.734  1.00 98.91           C  \\nATOM    230  N   PRO A  33     -12.040   7.413   2.345  1.00 98.09           N  \\nATOM    231  CA  PRO A  33     -13.180   7.207   1.444  1.00 98.09           C  \\nATOM    232  C   PRO A  33     -12.918   7.650   0.012  1.00 98.09           C  \\nATOM    233  O   PRO A  33     -13.444   7.031  -0.923  1.00 98.09           O  \\nATOM    234  CB  PRO A  33     -14.283   8.052   2.092  1.00 98.09           C  \\nATOM    235  CG  PRO A  33     -13.928   8.078   3.539  1.00 98.09           C  \\nATOM    236  CD  PRO A  33     -12.424   8.120   3.580  1.00 98.09           C  \\nATOM    237  N   ASP A  34     -12.135   8.702  -0.170  1.00 98.23           N  \\nATOM    238  CA  ASP A  34     -11.816   9.229  -1.492  1.00 98.23           C  \\nATOM    239  C   ASP A  34     -10.395   8.880  -1.927  1.00 98.23           C  \\nATOM    240  O   ASP A  34      -9.781   9.622  -2.693  1.00 98.23           O  \\nATOM    241  CB  ASP A  34     -12.033  10.744  -1.527  1.00 98.23           C  \\nATOM    242  CG  ASP A  34     -11.189  11.483  -0.505  1.00 98.23           C  \\nATOM    243  OD1 ASP A  34     -10.611  10.843   0.395  1.00 98.23           O  \\nATOM    244  OD2 ASP A  34     -11.116  12.730  -0.607  1.00 98.23           O  \\nATOM    245  N   ALA A  35      -9.879   7.753  -1.465  1.00 98.95           N  \\nATOM    246  CA  ALA A  35      -8.537   7.323  -1.839  1.00 98.95           C  \\nATOM    247  C   ALA A  35      -8.445   7.055  -3.337  1.00 98.95           C  \\nATOM    248  O   ALA A  35      -9.423   6.670  -3.982  1.00 98.95           O  \\nATOM    249  CB  ALA A  35      -8.144   6.071  -1.064  1.00 98.95           C  \\nATOM    250  N   THR A  36      -7.256   7.261  -3.883  1.00 98.90           N  \\nATOM    251  CA  THR A  36      -6.978   6.997  -5.290  1.00 98.90           C  \\nATOM    252  C   THR A  36      -5.679   6.221  -5.417  1.00 98.90           C  \\nATOM    253  O   THR A  36      -4.831   6.247  -4.522  1.00 98.90           O  \\nATOM    254  CB  THR A  36      -6.862   8.297  -6.103  1.00 98.90           C  \\nATOM    255  OG1 THR A  36      -5.755   9.064  -5.617  1.00 98.90           O  \\nATOM    256  CG2 THR A  36      -8.132   9.127  -5.999  1.00 98.90           C  \\nATOM    257  N   MET A  37      -5.531   5.533  -6.544  1.00 98.89           N  \\nATOM    258  CA  MET A  37      -4.286   4.847  -6.847  1.00 98.89           C  \\nATOM    259  C   MET A  37      -3.936   5.051  -8.310  1.00 98.89           C  \\nATOM    260  O   MET A  37      -4.787   4.871  -9.186  1.00 98.89           O  \\nATOM    261  CB  MET A  37      -4.364   3.349  -6.540  1.00 98.89           C  \\nATOM    262  CG  MET A  37      -3.029   2.628  -6.769  1.00 98.89           C  \\nATOM    263  SD  MET A  37      -2.936   0.980  -6.046  1.00 98.89           S  \\nATOM    264  CE  MET A  37      -4.025   0.079  -7.140  1.00 98.89           C  \\nATOM    265  N   THR A  38      -2.693   5.427  -8.564  1.00 98.63           N  \\nATOM    266  CA  THR A  38      -2.168   5.566  -9.913  1.00 98.63           C  \\nATOM    267  C   THR A  38      -1.156   4.458 -10.158  1.00 98.63           C  \\nATOM    268  O   THR A  38      -0.170   4.338  -9.430  1.00 98.63           O  \\nATOM    269  CB  THR A  38      -1.523   6.937 -10.121  1.00 98.63           C  \\nATOM    270  OG1 THR A  38      -2.484   7.964  -9.855  1.00 98.63           O  \\nATOM    271  CG2 THR A  38      -1.010   7.086 -11.547  1.00 98.63           C  \\nATOM    272  N   LEU A  39      -1.412   3.647 -11.178  1.00 98.22           N  \\nATOM    273  CA  LEU A  39      -0.533   2.544 -11.523  1.00 98.22           C  \\nATOM    274  C   LEU A  39       0.682   3.046 -12.284  1.00 98.22           C  \\nATOM    275  O   LEU A  39       0.724   4.183 -12.754  1.00 98.22           O  \\nATOM    276  CB  LEU A  39      -1.291   1.505 -12.350  1.00 98.22           C  \\nATOM    277  CG  LEU A  39      -2.576   0.973 -11.722  1.00 98.22           C  \\nATOM    278  CD1 LEU A  39      -3.198  -0.090 -12.620  1.00 98.22           C  \\nATOM    279  CD2 LEU A  39      -2.306   0.401 -10.335  1.00 98.22           C  \\nATOM    280  N   SER A  40       1.676   2.182 -12.433  1.00 96.66           N  \\nATOM    281  CA  SER A  40       2.922   2.586 -13.074  1.00 96.66           C  \\nATOM    282  C   SER A  40       2.745   2.941 -14.547  1.00 96.66           C  \\nATOM    283  O   SER A  40       3.581   3.659 -15.099  1.00 96.66           O  \\nATOM    284  CB  SER A  40       3.980   1.492 -12.923  1.00 96.66           C  \\nATOM    285  OG  SER A  40       3.549   0.278 -13.512  1.00 96.66           O  \\nATOM    286  N   ASP A  41       1.685   2.466 -15.177  1.00 96.38           N  \\nATOM    287  CA  ASP A  41       1.410   2.830 -16.557  1.00 96.38           C  \\nATOM    288  C   ASP A  41       0.557   4.088 -16.676  1.00 96.38           C  \\nATOM    289  O   ASP A  41       0.158   4.455 -17.783  1.00 96.38           O  \\nATOM    290  CB  ASP A  41       0.754   1.669 -17.312  1.00 96.38           C  \\nATOM    291  CG  ASP A  41      -0.642   1.334 -16.816  1.00 96.38           C  \\nATOM    292  OD1 ASP A  41      -1.150   2.002 -15.892  1.00 96.38           O  \\nATOM    293  OD2 ASP A  41      -1.240   0.386 -17.361  1.00 96.38           O  \\nATOM    294  N   GLY A  42       0.265   4.740 -15.556  1.00 97.57           N  \\nATOM    295  CA  GLY A  42      -0.514   5.961 -15.545  1.00 97.57           C  \\nATOM    296  C   GLY A  42      -2.004   5.770 -15.344  1.00 97.57           C  \\nATOM    297  O   GLY A  42      -2.727   6.760 -15.182  1.00 97.57           O  \\nATOM    298  N   THR A  43      -2.485   4.535 -15.343  1.00 98.27           N  \\nATOM    299  CA  THR A  43      -3.900   4.267 -15.106  1.00 98.27           C  \\nATOM    300  C   THR A  43      -4.274   4.716 -13.702  1.00 98.27           C  \\nATOM    301  O   THR A  43      -3.553   4.438 -12.744  1.00 98.27           O  \\nATOM    302  CB  THR A  43      -4.200   2.773 -15.271  1.00 98.27           C  \\nATOM    303  OG1 THR A  43      -3.853   2.367 -16.594  1.00 98.27           O  \\nATOM    304  CG2 THR A  43      -5.667   2.475 -14.988  1.00 98.27           C  \\nATOM    305  N   LYS A  44      -5.398   5.415 -13.581  1.00 98.46           N  \\nATOM    306  CA  LYS A  44      -5.840   5.944 -12.301  1.00 98.46           C  \\nATOM    307  C   LYS A  44      -7.109   5.246 -11.848  1.00 98.46           C  \\nATOM    308  O   LYS A  44      -8.072   5.136 -12.605  1.00 98.46           O  \\nATOM    309  CB  LYS A  44      -6.078   7.448 -12.387  1.00 98.46           C  \\nATOM    310  CG  LYS A  44      -4.813   8.234 -12.676  1.00 98.46           C  \\nATOM    311  CD  LYS A  44      -5.073   9.725 -12.714  1.00 98.46           C  \\nATOM    312  CE  LYS A  44      -3.792  10.494 -12.997  1.00 98.46           C  \\nATOM    313  NZ  LYS A  44      -4.020  11.967 -13.036  1.00 98.46           N  \\nATOM    314  N   LEU A  45      -7.084   4.767 -10.617  1.00 98.89           N  \\nATOM    315  CA  LEU A  45      -8.256   4.221  -9.956  1.00 98.89           C  \\nATOM    316  C   LEU A  45      -8.736   5.263  -8.964  1.00 98.89           C  \\nATOM    317  O   LEU A  45      -7.983   5.684  -8.089  1.00 98.89           O  \\nATOM    318  CB  LEU A  45      -7.918   2.909  -9.242  1.00 98.89           C  \\nATOM    319  CG  LEU A  45      -7.249   1.845 -10.106  1.00 98.89           C  \\nATOM    320  CD1 LEU A  45      -6.929   0.607  -9.276  1.00 98.89           C  \\nATOM    321  CD2 LEU A  45      -8.128   1.484 -11.291  1.00 98.89           C  \\nATOM    322  N   THR A  46      -9.984   5.703  -9.111  1.00 98.63           N  \\nATOM    323  CA  THR A  46     -10.480   6.853  -8.369  1.00 98.63           C  \\nATOM    324  C   THR A  46     -11.555   6.509  -7.351  1.00 98.63           C  \\nATOM    325  O   THR A  46     -12.139   7.414  -6.750  1.00 98.63           O  \\nATOM    326  CB  THR A  46     -11.015   7.920  -9.327  1.00 98.63           C  \\nATOM    327  OG1 THR A  46     -12.051   7.359 -10.137  1.00 98.63           O  \\nATOM    328  CG2 THR A  46      -9.896   8.436 -10.224  1.00 98.63           C  \\nATOM    329  N   LYS A  47     -11.829   5.229  -7.151  1.00 98.73           N  \\nATOM    330  CA  LYS A  47     -12.783   4.795  -6.141  1.00 98.73           C  \\nATOM    331  C   LYS A  47     -12.120   3.774  -5.235  1.00 98.73           C  \\nATOM    332  O   LYS A  47     -11.381   2.907  -5.702  1.00 98.73           O  \\nATOM    333  CB  LYS A  47     -14.027   4.166  -6.769  1.00 98.73           C  \\nATOM    334  CG  LYS A  47     -14.858   5.117  -7.606  1.00 98.73           C  \\nATOM    335  CD  LYS A  47     -16.105   4.426  -8.122  1.00 98.73           C  \\nATOM    336  CE  LYS A  47     -16.971   5.375  -8.931  1.00 98.73           C  \\nATOM    337  NZ  LYS A  47     -18.209   4.703  -9.419  1.00 98.73           N  \\nATOM    338  N   LYS A  48     -12.401   3.881  -3.944  1.00 98.63           N  \\nATOM    339  CA  LYS A  48     -11.828   2.942  -2.983  1.00 98.63           C  \\nATOM    340  C   LYS A  48     -12.135   1.496  -3.358  1.00 98.63           C  \\nATOM    341  O   LYS A  48     -11.262   0.626  -3.272  1.00 98.63           O  \\nATOM    342  CB  LYS A  48     -12.345   3.255  -1.577  1.00 98.63           C  \\nATOM    343  CG  LYS A  48     -11.897   2.243  -0.529  1.00 98.63           C  \\nATOM    344  CD  LYS A  48     -11.944   2.794   0.882  1.00 98.63           C  \\nATOM    345  CE  LYS A  48     -13.333   3.077   1.362  1.00 98.63           C  \\nATOM    346  NZ  LYS A  48     -13.339   3.453   2.804  1.00 98.63           N  \\nATOM    347  N   GLU A  49     -13.368   1.232  -3.772  1.00 98.33           N  \\nATOM    348  CA  GLU A  49     -13.733  -0.139  -4.108  1.00 98.33           C  \\nATOM    349  C   GLU A  49     -13.004  -0.640  -5.351  1.00 98.33           C  \\nATOM    350  O   GLU A  49     -12.733  -1.839  -5.466  1.00 98.33           O  \\nATOM    351  CB  GLU A  49     -15.242  -0.261  -4.280  1.00 98.33           C  \\nATOM    352  CG  GLU A  49     -16.009  -0.044  -2.984  1.00 98.33           C  \\nATOM    353  CD  GLU A  49     -15.553  -0.954  -1.860  1.00 98.33           C  \\nATOM    354  OE1 GLU A  49     -15.277  -2.148  -2.123  1.00 98.33           O  \\nATOM    355  OE2 GLU A  49     -15.463  -0.481  -0.705  1.00 98.33           O  \\nATOM    356  N   ASP A  50     -12.677   0.242  -6.287  1.00 98.87           N  \\nATOM    357  CA  ASP A  50     -11.858  -0.157  -7.427  1.00 98.87           C  \\nATOM    358  C   ASP A  50     -10.451  -0.541  -6.979  1.00 98.87           C  \\nATOM    359  O   ASP A  50      -9.849  -1.468  -7.525  1.00 98.87           O  \\nATOM    360  CB  ASP A  50     -11.773   0.973  -8.460  1.00 98.87           C  \\nATOM    361  CG  ASP A  50     -13.083   1.218  -9.181  1.00 98.87           C  \\nATOM    362  OD1 ASP A  50     -13.962   0.330  -9.166  1.00 98.87           O  \\nATOM    363  OD2 ASP A  50     -13.226   2.306  -9.781  1.00 98.87           O  \\nATOM    364  N   ILE A  51      -9.925   0.181  -5.999  1.00 98.97           N  \\nATOM    365  CA  ILE A  51      -8.588  -0.118  -5.499  1.00 98.97           C  \\nATOM    366  C   ILE A  51      -8.558  -1.496  -4.848  1.00 98.97           C  \\nATOM    367  O   ILE A  51      -7.683  -2.320  -5.139  1.00 98.97           O  \\nATOM    368  CB  ILE A  51      -8.115   0.969  -4.513  1.00 98.97           C  \\nATOM    369  CG1 ILE A  51      -7.974   2.311  -5.239  1.00 98.97           C  \\nATOM    370  CG2 ILE A  51      -6.791   0.566  -3.867  1.00 98.97           C  \\nATOM    371  CD1 ILE A  51      -7.783   3.490  -4.303  1.00 98.97           C  \\nATOM    372  N   VAL A  52      -9.497  -1.760  -3.944  1.00 98.54           N  \\nATOM    373  CA  VAL A  52      -9.472  -3.047  -3.261  1.00 98.54           C  \\nATOM    374  C   VAL A  52      -9.764  -4.185  -4.234  1.00 98.54           C  \\nATOM    375  O   VAL A  52      -9.206  -5.278  -4.100  1.00 98.54           O  \\nATOM    376  CB  VAL A  52     -10.412  -3.091  -2.033  1.00 98.54           C  \\nATOM    377  CG1 VAL A  52      -9.955  -2.079  -0.988  1.00 98.54           C  \\nATOM    378  CG2 VAL A  52     -11.861  -2.854  -2.423  1.00 98.54           C  \\nATOM    379  N   ALA A  53     -10.611  -3.950  -5.232  1.00 98.86           N  \\nATOM    380  CA  ALA A  53     -10.858  -4.969  -6.247  1.00 98.86           C  \\nATOM    381  C   ALA A  53      -9.600  -5.251  -7.056  1.00 98.86           C  \\nATOM    382  O   ALA A  53      -9.326  -6.404  -7.406  1.00 98.86           O  \\nATOM    383  CB  ALA A  53     -11.996  -4.543  -7.171  1.00 98.86           C  \\nATOM    384  N   TYR A  54      -8.847  -4.216  -7.365  1.00 98.89           N  \\nATOM    385  CA  TYR A  54      -7.604  -4.400  -8.106  1.00 98.89           C  \\nATOM    386  C   TYR A  54      -6.618  -5.250  -7.309  1.00 98.89           C  \\nATOM    387  O   TYR A  54      -5.974  -6.151  -7.857  1.00 98.89           O  \\nATOM    388  CB  TYR A  54      -6.980  -3.046  -8.447  1.00 98.89           C  \\nATOM    389  CG  TYR A  54      -5.799  -3.147  -9.383  1.00 98.89           C  \\nATOM    390  CD1 TYR A  54      -5.995  -3.290 -10.754  1.00 98.89           C  \\nATOM    391  CD2 TYR A  54      -4.500  -3.104  -8.908  1.00 98.89           C  \\nATOM    392  CE1 TYR A  54      -4.919  -3.388 -11.625  1.00 98.89           C  \\nATOM    393  CE2 TYR A  54      -3.419  -3.199  -9.773  1.00 98.89           C  \\nATOM    394  CZ  TYR A  54      -3.638  -3.343 -11.126  1.00 98.89           C  \\nATOM    395  OH  TYR A  54      -2.567  -3.443 -11.988  1.00 98.89           O  \\nATOM    396  N   TYR A  55      -6.487  -4.976  -6.018  1.00 98.95           N  \\nATOM    397  CA  TYR A  55      -5.606  -5.785  -5.178  1.00 98.95           C  \\nATOM    398  C   TYR A  55      -6.105  -7.220  -5.059  1.00 98.95           C  \\nATOM    399  O   TYR A  55      -5.304  -8.158  -5.042  1.00 98.95           O  \\nATOM    400  CB  TYR A  55      -5.450  -5.155  -3.792  1.00 98.95           C  \\nATOM    401  CG  TYR A  55      -4.402  -4.067  -3.754  1.00 98.95           C  \\nATOM    402  CD1 TYR A  55      -3.052  -4.392  -3.838  1.00 98.95           C  \\nATOM    403  CD2 TYR A  55      -4.753  -2.730  -3.634  1.00 98.95           C  \\nATOM    404  CE1 TYR A  55      -2.077  -3.404  -3.801  1.00 98.95           C  \\nATOM    405  CE2 TYR A  55      -3.786  -1.734  -3.597  1.00 98.95           C  \\nATOM    406  CZ  TYR A  55      -2.448  -2.076  -3.679  1.00 98.95           C  \\nATOM    407  OH  TYR A  55      -1.491  -1.105  -3.640  1.00 98.95           O  \\nATOM    408  N   LYS A  56      -7.417  -7.407  -4.960  1.00 98.82           N  \\nATOM    409  CA  LYS A  56      -7.953  -8.759  -4.889  1.00 98.82           C  \\nATOM    410  C   LYS A  56      -7.630  -9.533  -6.165  1.00 98.82           C  \\nATOM    411  O   LYS A  56      -7.225 -10.697  -6.110  1.00 98.82           O  \\nATOM    412  CB  LYS A  56      -9.461  -8.724  -4.641  1.00 98.82           C  \\nATOM    413  CG  LYS A  56     -10.081 -10.100  -4.486  1.00 98.82           C  \\nATOM    414  CD  LYS A  56     -11.562  -9.997  -4.137  1.00 98.82           C  \\nATOM    415  CE  LYS A  56     -12.145 -11.348  -3.745  1.00 98.82           C  \\nATOM    416  NZ  LYS A  56     -12.127 -12.308  -4.882  1.00 98.82           N  \\nATOM    417  N   GLU A  57      -7.800  -8.888  -7.310  1.00 98.76           N  \\nATOM    418  CA  GLU A  57      -7.466  -9.528  -8.574  1.00 98.76           C  \\nATOM    419  C   GLU A  57      -5.978  -9.842  -8.654  1.00 98.76           C  \\nATOM    420  O   GLU A  57      -5.583 -10.908  -9.138  1.00 98.76           O  \\nATOM    421  CB  GLU A  57      -7.878  -8.643  -9.749  1.00 98.76           C  \\nATOM    422  CG  GLU A  57      -9.383  -8.515  -9.921  1.00 98.76           C  \\nATOM    423  CD  GLU A  57      -9.769  -7.538 -11.020  1.00 98.76           C  \\nATOM    424  OE1 GLU A  57      -8.871  -6.873 -11.583  1.00 98.76           O  \\nATOM    425  OE2 GLU A  57     -10.973  -7.438 -11.317  1.00 98.76           O  \\nATOM    426  N   GLY A  58      -5.152  -8.912  -8.185  1.00 98.77           N  \\nATOM    427  CA  GLY A  58      -3.720  -9.164  -8.178  1.00 98.77           C  \\nATOM    428  C   GLY A  58      -3.360 -10.366  -7.325  1.00 98.77           C  \\nATOM    429  O   GLY A  58      -2.574 -11.230  -7.736  1.00 98.77           O  \\nATOM    430  N   TYR A  59      -3.928 -10.420  -6.145  1.00 98.87           N  \\nATOM    431  CA  TYR A  59      -3.711 -11.562  -5.267  1.00 98.87           C  \\nATOM    432  C   TYR A  59      -4.122 -12.865  -5.948  1.00 98.87           C  \\nATOM    433  O   TYR A  59      -3.393 -13.860  -5.907  1.00 98.87           O  \\nATOM    434  CB  TYR A  59      -4.488 -11.358  -3.965  1.00 98.87           C  \\nATOM    435  CG  TYR A  59      -4.600 -12.598  -3.122  1.00 98.87           C  \\nATOM    436  CD1 TYR A  59      -3.529 -13.038  -2.355  1.00 98.87           C  \\nATOM    437  CD2 TYR A  59      -5.783 -13.329  -3.093  1.00 98.87           C  \\nATOM    438  CE1 TYR A  59      -3.632 -14.177  -1.575  1.00 98.87           C  \\nATOM    439  CE2 TYR A  59      -5.895 -14.472  -2.314  1.00 98.87           C  \\nATOM    440  CZ  TYR A  59      -4.817 -14.889  -1.559  1.00 98.87           C  \\nATOM    441  OH  TYR A  59      -4.927 -16.016  -0.791  1.00 98.87           O  \\nATOM    442  N   GLU A  60      -5.286 -12.869  -6.575  1.00 98.62           N  \\nATOM    443  CA  GLU A  60      -5.785 -14.073  -7.221  1.00 98.62           C  \\nATOM    444  C   GLU A  60      -4.920 -14.498  -8.398  1.00 98.62           C  \\nATOM    445  O   GLU A  60      -4.889 -15.682  -8.752  1.00 98.62           O  \\nATOM    446  CB  GLU A  60      -7.232 -13.868  -7.659  1.00 98.62           C  \\nATOM    447  CG  GLU A  60      -8.195 -13.785  -6.482  1.00 98.62           C  \\nATOM    448  CD  GLU A  60      -9.593 -13.368  -6.880  1.00 98.62           C  \\nATOM    449  OE1 GLU A  60      -9.782 -12.876  -8.012  1.00 98.62           O  \\nATOM    450  OE2 GLU A  60     -10.506 -13.525  -6.046  1.00 98.62           O  \\nATOM    451  N   ASN A  61      -4.218 -13.547  -8.995  1.00 98.28           N  \\nATOM    452  CA  ASN A  61      -3.310 -13.834 -10.096  1.00 98.28           C  \\nATOM    453  C   ASN A  61      -1.870 -14.061  -9.649  1.00 98.28           C  \\nATOM    454  O   ASN A  61      -0.963 -14.091 -10.485  1.00 98.28           O  \\nATOM    455  CB  ASN A  61      -3.387 -12.725 -11.141  1.00 98.28           C  \\nATOM    456  CG  ASN A  61      -4.646 -12.827 -11.971  1.00 98.28           C  \\nATOM    457  OD1 ASN A  61      -4.800 -13.759 -12.753  1.00 98.28           O  \\nATOM    458  ND2 ASN A  61      -5.554 -11.880 -11.800  1.00 98.28           N  \\nATOM    459  N   GLY A  62      -1.659 -14.215  -8.362  1.00 98.78           N  \\nATOM    460  CA  GLY A  62      -0.368 -14.625  -7.838  1.00 98.78           C  \\nATOM    461  C   GLY A  62       0.595 -13.500  -7.526  1.00 98.78           C  \\nATOM    462  O   GLY A  62       1.752 -13.769  -7.188  1.00 98.78           O  \\nATOM    463  N   TYR A  63       0.147 -12.252  -7.605  1.00 98.71           N  \\nATOM    464  CA  TYR A  63       1.042 -11.136  -7.353  1.00 98.71           C  \\nATOM    465  C   TYR A  63       1.243 -10.907  -5.866  1.00 98.71           C  \\nATOM    466  O   TYR A  63       0.310 -11.031  -5.069  1.00 98.71           O  \\nATOM    467  CB  TYR A  63       0.519  -9.855  -8.003  1.00 98.71           C  \\nATOM    468  CG  TYR A  63       0.624  -9.878  -9.508  1.00 98.71           C  \\nATOM    469  CD1 TYR A  63       1.822  -9.559 -10.135  1.00 98.71           C  \\nATOM    470  CD2 TYR A  63      -0.458 -10.228 -10.296  1.00 98.71           C  \\nATOM    471  CE1 TYR A  63       1.936  -9.581 -11.516  1.00 98.71           C  \\nATOM    472  CE2 TYR A  63      -0.359 -10.255 -11.680  1.00 98.71           C  \\nATOM    473  CZ  TYR A  63       0.842  -9.929 -12.283  1.00 98.71           C  \\nATOM    474  OH  TYR A  63       0.947  -9.950 -13.648  1.00 98.71           O  \\nATOM    475  N   ARG A  64       2.471 -10.562  -5.508  1.00 98.22           N  \\nATOM    476  CA  ARG A  64       2.837 -10.137  -4.168  1.00 98.22           C  \\nATOM    477  C   ARG A  64       3.630  -8.848  -4.248  1.00 98.22           C  \\nATOM    478  O   ARG A  64       4.378  -8.629  -5.197  1.00 98.22           O  \\nATOM    479  CB  ARG A  64       3.683 -11.189  -3.447  1.00 98.22           C  \\nATOM    480  CG  ARG A  64       2.934 -12.430  -3.022  1.00 98.22           C  \\nATOM    481  CD  ARG A  64       3.780 -13.271  -2.062  1.00 98.22           C  \\nATOM    482  NE  ARG A  64       3.852 -12.661  -0.732  1.00 98.22           N  \\nATOM    483  CZ  ARG A  64       4.900 -12.000  -0.227  1.00 98.22           C  \\nATOM    484  NH1 ARG A  64       6.015 -11.862  -0.935  1.00 98.22           N  \\nATOM    485  NH2 ARG A  64       4.836 -11.491   0.994  1.00 98.22           N  \\nATOM    486  N   ILE A  65       3.466  -8.014  -3.220  1.00 96.79           N  \\nATOM    487  CA  ILE A  65       4.205  -6.769  -3.094  1.00 96.79           C  \\nATOM    488  C   ILE A  65       5.312  -6.970  -2.080  1.00 96.79           C  \\nATOM    489  O   ILE A  65       5.065  -7.473  -0.981  1.00 96.79           O  \\nATOM    490  CB  ILE A  65       3.305  -5.619  -2.610  1.00 96.79           C  \\nATOM    491  CG1 ILE A  65       2.005  -5.559  -3.404  1.00 96.79           C  \\nATOM    492  CG2 ILE A  65       4.048  -4.290  -2.695  1.00 96.79           C  \\nATOM    493  CD1 ILE A  65       0.930  -4.766  -2.699  1.00 96.79           C  \\nATOM    494  N   GLU A  66       6.516  -6.577  -2.443  1.00 96.81           N  \\nATOM    495  CA  GLU A  66       7.633  -6.580  -1.508  1.00 96.81           C  \\nATOM    496  C   GLU A  66       8.306  -5.222  -1.598  1.00 96.81           C  \\nATOM    497  O   GLU A  66       8.974  -4.919  -2.581  1.00 96.81           O  \\nATOM    498  CB  GLU A  66       8.626  -7.692  -1.832  1.00 96.81           C  \\nATOM    499  CG  GLU A  66       8.031  -9.088  -1.717  1.00 96.81           C  \\nATOM    500  CD  GLU A  66       9.038 -10.195  -1.973  1.00 96.81           C  \\nATOM    501  OE1 GLU A  66      10.159  -9.899  -2.446  1.00 96.81           O  \\nATOM    502  OE2 GLU A  66       8.703 -11.365  -1.708  1.00 96.81           O  \\nATOM    503  N   VAL A  67       8.099  -4.391  -0.566  1.00 96.63           N  \\nATOM    504  CA  VAL A  67       8.637  -3.035  -0.566  1.00 96.63           C  \\nATOM    505  C   VAL A  67       9.370  -2.752   0.735  1.00 96.63           C  \\nATOM    506  O   VAL A  67       9.055  -3.315   1.781  1.00 96.63           O  \\nATOM    507  CB  VAL A  67       7.543  -1.962  -0.779  1.00 96.63           C  \\nATOM    508  CG1 VAL A  67       6.919  -2.102  -2.154  1.00 96.63           C  \\nATOM    509  CG2 VAL A  67       6.488  -2.051   0.317  1.00 96.63           C  \\nATOM    510  N   ASP A  68      10.343  -1.881   0.630  1.00 97.92           N  \\nATOM    511  CA  ASP A  68      11.018  -1.307   1.781  1.00 97.92           C  \\nATOM    512  C   ASP A  68      10.638   0.161   1.856  1.00 97.92           C  \\nATOM    513  O   ASP A  68      10.841   0.899   0.902  1.00 97.92           O  \\nATOM    514  CB  ASP A  68      12.537  -1.431   1.653  1.00 97.92           C  \\nATOM    515  CG  ASP A  68      13.011  -2.866   1.719  1.00 97.92           C  \\nATOM    516  OD1 ASP A  68      12.570  -3.601   2.624  1.00 97.92           O  \\nATOM    517  OD2 ASP A  68      13.839  -3.244   0.872  1.00 97.92           O  \\nATOM    518  N   ILE A  69      10.085   0.582   3.001  1.00 98.37           N  \\nATOM    519  CA  ILE A  69       9.739   1.982   3.186  1.00 98.37           C  \\nATOM    520  C   ILE A  69      11.026   2.753   3.449  1.00 98.37           C  \\nATOM    521  O   ILE A  69      11.728   2.491   4.427  1.00 98.37           O  \\nATOM    522  CB  ILE A  69       8.730   2.165   4.331  1.00 98.37           C  \\nATOM    523  CG1 ILE A  69       7.441   1.403   3.999  1.00 98.37           C  \\nATOM    524  CG2 ILE A  69       8.441   3.646   4.550  1.00 98.37           C  \\nATOM    525  CD1 ILE A  69       6.442   1.352   5.139  1.00 98.37           C  \\nATOM    526  N   LEU A  70      11.331   3.687   2.562  1.00 98.36           N  \\nATOM    527  CA  LEU A  70      12.585   4.426   2.623  1.00 98.36           C  \\nATOM    528  C   LEU A  70      12.487   5.680   3.472  1.00 98.36           C  \\nATOM    529  O   LEU A  70      13.460   6.066   4.122  1.00 98.36           O  \\nATOM    530  CB  LEU A  70      13.040   4.818   1.213  1.00 98.36           C  \\nATOM    531  CG  LEU A  70      13.213   3.668   0.226  1.00 98.36           C  \\nATOM    532  CD1 LEU A  70      13.576   4.211  -1.151  1.00 98.36           C  \\nATOM    533  CD2 LEU A  70      14.273   2.699   0.729  1.00 98.36           C  \\nATOM    534  N   SER A  71      11.341   6.339   3.445  1.00 97.95           N  \\nATOM    535  CA  SER A  71      11.183   7.590   4.169  1.00 97.95           C  \\nATOM    536  C   SER A  71       9.709   7.886   4.368  1.00 97.95           C  \\nATOM    537  O   SER A  71       8.863   7.436   3.593  1.00 97.95           O  \\nATOM    538  CB  SER A  71      11.833   8.757   3.418  1.00 97.95           C  \\nATOM    539  OG  SER A  71      11.156   9.002   2.191  1.00 97.95           O  \\nATOM    540  N   VAL A  72       9.427   8.640   5.414  1.00 98.73           N  \\nATOM    541  CA  VAL A  72       8.105   9.205   5.645  1.00 98.73           C  \\nATOM    542  C   VAL A  72       8.313  10.665   5.996  1.00 98.73           C  \\nATOM    543  O   VAL A  72       8.966  10.977   6.992  1.00 98.73           O  \\nATOM    544  CB  VAL A  72       7.340   8.492   6.775  1.00 98.73           C  \\nATOM    545  CG1 VAL A  72       5.986   9.161   6.994  1.00 98.73           C  \\nATOM    546  CG2 VAL A  72       7.164   7.014   6.443  1.00 98.73           C  \\nATOM    547  N   GLU A  73       7.783  11.545   5.162  1.00 98.53           N  \\nATOM    548  CA  GLU A  73       7.910  12.980   5.357  1.00 98.53           C  \\nATOM    549  C   GLU A  73       6.588  13.531   5.861  1.00 98.53           C  \\nATOM    550  O   GLU A  73       5.578  13.461   5.163  1.00 98.53           O  \\nATOM    551  CB  GLU A  73       8.313  13.669   4.057  1.00 98.53           C  \\nATOM    552  CG  GLU A  73       8.492  15.173   4.199  1.00 98.53           C  \\nATOM    553  CD  GLU A  73       8.900  15.847   2.893  1.00 98.53           C  \\nATOM    554  OE1 GLU A  73       8.954  15.164   1.855  1.00 98.53           O  \\nATOM    555  OE2 GLU A  73       9.160  17.063   2.928  1.00 98.53           O  \\nATOM    556  N   VAL A  74       6.604  14.078   7.063  1.00 98.09           N  \\nATOM    557  CA  VAL A  74       5.414  14.685   7.636  1.00 98.09           C  \\nATOM    558  C   VAL A  74       5.227  16.076   7.045  1.00 98.09           C  \\nATOM    559  O   VAL A  74       6.180  16.845   6.932  1.00 98.09           O  \\nATOM    560  CB  VAL A  74       5.513  14.753   9.170  1.00 98.09           C  \\nATOM    561  CG1 VAL A  74       4.313  15.495   9.753  1.00 98.09           C  \\nATOM    562  CG2 VAL A  74       5.609  13.341   9.743  1.00 98.09           C  \\nATOM    563  N   ILE A  75       3.996  16.391   6.665  1.00 97.45           N  \\nATOM    564  CA  ILE A  75       3.640  17.676   6.080  1.00 97.45           C  \\nATOM    565  C   ILE A  75       2.549  18.282   6.946  1.00 97.45           C  \\nATOM    566  O   ILE A  75       1.430  17.771   6.993  1.00 97.45           O  \\nATOM    567  CB  ILE A  75       3.149  17.523   4.629  1.00 97.45           C  \\nATOM    568  CG1 ILE A  75       4.213  16.813   3.786  1.00 97.45           C  \\nATOM    569  CG2 ILE A  75       2.800  18.885   4.041  1.00 97.45           C  \\nATOM    570  CD1 ILE A  75       3.723  16.420   2.406  1.00 97.45           C  \\nATOM    571  N   GLY A  76       2.883  19.356   7.637  1.00 97.50           N  \\nATOM    572  CA  GLY A  76       1.926  19.955   8.543  1.00 97.50           C  \\nATOM    573  C   GLY A  76       1.629  19.030   9.705  1.00 97.50           C  \\nATOM    574  O   GLY A  76       2.483  18.258  10.152  1.00 97.50           O  \\nATOM    575  N   ASP A  77       0.407  19.101  10.190  1.00 95.21           N  \\nATOM    576  CA  ASP A  77       0.016  18.347  11.372  1.00 95.21           C  \\nATOM    577  C   ASP A  77      -0.721  17.055  11.064  1.00 95.21           C  \\nATOM    578  O   ASP A  77      -0.816  16.186  11.936  1.00 95.21           O  \\nATOM    579  CB  ASP A  77      -0.860  19.210  12.284  1.00 95.21           C  \\nATOM    580  CG  ASP A  77      -0.101  20.382  12.879  1.00 95.21           C  \\nATOM    581  OD1 ASP A  77       1.118  20.267  13.092  1.00 95.21           O  \\nATOM    582  OD2 ASP A  77      -0.743  21.420  13.146  1.00 95.21           O  \\nATOM    583  N   ASN A  78      -1.266  16.912   9.854  1.00 97.28           N  \\nATOM    584  CA  ASN A  78      -2.154  15.788   9.597  1.00 97.28           C  \\nATOM    585  C   ASN A  78      -1.931  15.108   8.252  1.00 97.28           C  \\nATOM    586  O   ASN A  78      -2.820  14.396   7.779  1.00 97.28           O  \\nATOM    587  CB  ASN A  78      -3.619  16.216   9.733  1.00 97.28           C  \\nATOM    588  CG  ASN A  78      -4.030  17.234   8.687  1.00 97.28           C  \\nATOM    589  OD1 ASN A  78      -3.210  17.727   7.909  1.00 97.28           O  \\nATOM    590  ND2 ASN A  78      -5.313  17.554   8.653  1.00 97.28           N  \\nATOM    591  N   GLU A  79      -0.768  15.295   7.644  1.00 98.40           N  \\nATOM    592  CA  GLU A  79      -0.451  14.633   6.387  1.00 98.40           C  \\nATOM    593  C   GLU A  79       0.970  14.111   6.419  1.00 98.40           C  \\nATOM    594  O   GLU A  79       1.833  14.657   7.102  1.00 98.40           O  \\nATOM    595  CB  GLU A  79      -0.603  15.577   5.195  1.00 98.40           C  \\nATOM    596  CG  GLU A  79      -2.019  16.057   4.945  1.00 98.40           C  \\nATOM    597  CD  GLU A  79      -2.151  16.860   3.661  1.00 98.40           C  \\nATOM    598  OE1 GLU A  79      -1.118  17.195   3.037  1.00 98.40           O  \\nATOM    599  OE2 GLU A  79      -3.298  17.152   3.267  1.00 98.40           O  \\nATOM    600  N   ALA A  80       1.208  13.048   5.665  1.00 98.84           N  \\nATOM    601  CA  ALA A  80       2.542  12.499   5.508  1.00 98.84           C  \\nATOM    602  C   ALA A  80       2.622  11.793   4.171  1.00 98.84           C  \\nATOM    603  O   ALA A  80       1.617  11.298   3.657  1.00 98.84           O  \\nATOM    604  CB  ALA A  80       2.888  11.535   6.638  1.00 98.84           C  \\nATOM    605  N   VAL A  81       3.828  11.754   3.605  1.00 98.83           N  \\nATOM    606  CA  VAL A  81       4.080  11.072   2.345  1.00 98.83           C  \\nATOM    607  C   VAL A  81       5.198  10.070   2.566  1.00 98.83           C  \\nATOM    608  O   VAL A  81       6.275  10.431   3.037  1.00 98.83           O  \\nATOM    609  CB  VAL A  81       4.459  12.055   1.226  1.00 98.83           C  \\nATOM    610  CG1 VAL A  81       4.830  11.296  -0.043  1.00 98.83           C  \\nATOM    611  CG2 VAL A  81       3.306  13.017   0.960  1.00 98.83           C  \\nATOM    612  N   ALA A  82       4.926   8.818   2.242  1.00 98.87           N  \\nATOM    613  CA  ALA A  82       5.909   7.752   2.359  1.00 98.87           C  \\nATOM    614  C   ALA A  82       6.416   7.372   0.980  1.00 98.87           C  \\nATOM    615  O   ALA A  82       5.645   7.302   0.023  1.00 98.87           O  \\nATOM    616  CB  ALA A  82       5.308   6.529   3.039  1.00 98.87           C  \\nATOM    617  N   THR A  83       7.710   7.125   0.890  1.00 98.54           N  \\nATOM    618  CA  THR A  83       8.341   6.636  -0.325  1.00 98.54           C  \\nATOM    619  C   THR A  83       8.919   5.257  -0.053  1.00 98.54           C  \\nATOM    620  O   THR A  83       9.550   5.040   0.982  1.00 98.54           O  \\nATOM    621  CB  THR A  83       9.444   7.585  -0.797  1.00 98.54           C  \\nATOM    622  OG1 THR A  83       8.886   8.879  -1.041  1.00 98.54           O  \\nATOM    623  CG2 THR A  83      10.099   7.071  -2.072  1.00 98.54           C  \\nATOM    624  N   ALA A  84       8.698   4.331  -0.975  1.00 98.52           N  \\nATOM    625  CA  ALA A  84       9.201   2.974  -0.836  1.00 98.52           C  \\nATOM    626  C   ALA A  84       9.774   2.498  -2.157  1.00 98.52           C  \\nATOM    627  O   ALA A  84       9.475   3.047  -3.218  1.00 98.52           O  \\nATOM    628  CB  ALA A  84       8.102   2.030  -0.365  1.00 98.52           C  \\nATOM    629  N   LYS A  85      10.600   1.484  -2.079  1.00 97.46           N  \\nATOM    630  CA  LYS A  85      11.178   0.857  -3.257  1.00 97.46           C  \\nATOM    631  C   LYS A  85      11.013  -0.640  -3.118  1.00 97.46           C  \\nATOM    632  O   LYS A  85      11.214  -1.192  -2.034  1.00 97.46           O  \\nATOM    633  CB  LYS A  85      12.657   1.213  -3.395  1.00 97.46           C  \\nATOM    634  CG  LYS A  85      13.329   0.622  -4.623  1.00 97.46           C  \\nATOM    635  CD  LYS A  85      14.794   1.023  -4.693  1.00 97.46           C  \\nATOM    636  CE  LYS A  85      15.500   0.383  -5.878  1.00 97.46           C  \\nATOM    637  NZ  LYS A  85      16.950   0.734  -5.915  1.00 97.46           N  \\nATOM    638  N   GLY A  86      10.637  -1.298  -4.203  1.00 96.70           N  \\nATOM    639  CA  GLY A  86      10.468  -2.728  -4.110  1.00 96.70           C  \\nATOM    640  C   GLY A  86      10.061  -3.360  -5.413  1.00 96.70           C  \\nATOM    641  O   GLY A  86      10.325  -2.828  -6.494  1.00 96.70           O  \\nATOM    642  N   THR A  87       9.416  -4.515  -5.290  1.00 96.70           N  \\nATOM    643  CA  THR A  87       9.039  -5.309  -6.443  1.00 96.70           C  \\nATOM    644  C   THR A  87       7.613  -5.804  -6.308  1.00 96.70           C  \\nATOM    645  O   THR A  87       7.081  -5.948  -5.202  1.00 96.70           O  \\nATOM    646  CB  THR A  87       9.952  -6.531  -6.618  1.00 96.70           C  \\nATOM    647  OG1 THR A  87       9.865  -7.364  -5.458  1.00 96.70           O  \\nATOM    648  CG2 THR A  87      11.392  -6.107  -6.839  1.00 96.70           C  \\nATOM    649  N   ILE A  88       7.007  -6.051  -7.453  1.00 97.35           N  \\nATOM    650  CA  ILE A  88       5.748  -6.768  -7.544  1.00 97.35           C  \\nATOM    651  C   ILE A  88       6.041  -8.032  -8.328  1.00 97.35           C  \\nATOM    652  O   ILE A  88       6.576  -7.972  -9.435  1.00 97.35           O  \\nATOM    653  CB  ILE A  88       4.662  -5.927  -8.235  1.00 97.35           C  \\nATOM    654  CG1 ILE A  88       4.409  -4.655  -7.424  1.00 97.35           C  \\nATOM    655  CG2 ILE A  88       3.377  -6.725  -8.404  1.00 97.35           C  \\nATOM    656  CD1 ILE A  88       3.648  -3.601  -8.184  1.00 97.35           C  \\nATOM    657  N   LYS A  89       5.710  -9.176  -7.748  1.00 97.81           N  \\nATOM    658  CA  LYS A  89       6.055 -10.463  -8.336  1.00 97.81           C  \\nATOM    659  C   LYS A  89       4.817 -11.326  -8.485  1.00 97.81           C  \\nATOM    660  O   LYS A  89       3.948 -11.323  -7.617  1.00 97.81           O  \\nATOM    661  CB  LYS A  89       7.059 -11.215  -7.462  1.00 97.81           C  \\nATOM    662  CG  LYS A  89       8.333 -10.469  -7.158  1.00 97.81           C  \\nATOM    663  CD  LYS A  89       9.230 -11.304  -6.255  1.00 97.81           C  \\nATOM    664  CE  LYS A  89      10.502 -10.569  -5.887  1.00 97.81           C  \\nATOM    665  NZ  LYS A  89      11.343 -11.366  -4.949  1.00 97.81           N  \\nATOM    666  N   SER A  90       4.757 -12.094  -9.572  1.00 98.41           N  \\nATOM    667  CA  SER A  90       3.693 -13.059  -9.769  1.00 98.41           C  \\nATOM    668  C   SER A  90       4.260 -14.466  -9.677  1.00 98.41           C  \\nATOM    669  O   SER A  90       5.183 -14.814 -10.413  1.00 98.41           O  \\nATOM    670  CB  SER A  90       3.013 -12.883 -11.120  1.00 98.41           C  \\nATOM    671  OG  SER A  90       2.091 -13.938 -11.345  1.00 98.41           O  \\nATOM    672  N   SER A  91       3.699 -15.270  -8.796  1.00 98.23           N  \\nATOM    673  CA  SER A  91       4.093 -16.665  -8.687  1.00 98.23           C  \\nATOM    674  C   SER A  91       3.564 -17.500  -9.845  1.00 98.23           C  \\nATOM    675  O   SER A  91       4.043 -18.614 -10.060  1.00 98.23           O  \\nATOM    676  CB  SER A  91       3.610 -17.257  -7.367  1.00 98.23           C  \\nATOM    677  OG  SER A  91       2.199 -17.232  -7.286  1.00 98.23           O  \\nATOM    678  N   LYS A  92       2.590 -16.978 -10.582  1.00 98.07           N  \\nATOM    679  CA  LYS A  92       2.000 -17.737 -11.675  1.00 98.07           C  \\nATOM    680  C   LYS A  92       2.759 -17.573 -12.982  1.00 98.07           C  \\nATOM    681  O   LYS A  92       2.866 -18.524 -13.760  1.00 98.07           O  \\nATOM    682  CB  LYS A  92       0.535 -17.346 -11.868  1.00 98.07           C  \\nATOM    683  CG  LYS A  92      -0.344 -17.769 -10.710  1.00 98.07           C  \\nATOM    684  CD  LYS A  92      -1.808 -17.530 -11.006  1.00 98.07           C  \\nATOM    685  CE  LYS A  92      -2.680 -18.028  -9.867  1.00 98.07           C  \\nATOM    686  NZ  LYS A  92      -4.127 -17.813 -10.157  1.00 98.07           N  \\nATOM    687  N   THR A  93       3.285 -16.377 -13.243  1.00 97.39           N  \\nATOM    688  CA  THR A  93       3.965 -16.102 -14.503  1.00 97.39           C  \\nATOM    689  C   THR A  93       5.455 -15.858 -14.347  1.00 97.39           C  \\nATOM    690  O   THR A  93       6.184 -15.882 -15.339  1.00 97.39           O  \\nATOM    691  CB  THR A  93       3.365 -14.879 -15.201  1.00 97.39           C  \\nATOM    692  OG1 THR A  93       3.644 -13.699 -14.437  1.00 97.39           O  \\nATOM    693  CG2 THR A  93       1.861 -15.033 -15.355  1.00 97.39           C  \\nATOM    694  N   GLY A  94       5.919 -15.580 -13.135  1.00 98.07           N  \\nATOM    695  CA  GLY A  94       7.303 -15.203 -12.918  1.00 98.07           C  \\nATOM    696  C   GLY A  94       7.593 -13.741 -13.177  1.00 98.07           C  \\nATOM    697  O   GLY A  94       8.747 -13.317 -13.064  1.00 98.07           O  \\nATOM    698  N   GLU A  95       6.584 -12.973 -13.511  1.00 96.50           N  \\nATOM    699  CA  GLU A  95       6.766 -11.554 -13.772  1.00 96.50           C  \\nATOM    700  C   GLU A  95       7.306 -10.846 -12.537  1.00 96.50           C  \\nATOM    701  O   GLU A  95       6.838 -11.085 -11.423  1.00 96.50           O  \\nATOM    702  CB  GLU A  95       5.445 -10.913 -14.188  1.00 96.50           C  \\nATOM    703  CG  GLU A  95       5.535  -9.429 -14.500  1.00 96.50           C  \\nATOM    704  CD  GLU A  95       4.191  -8.818 -14.855  1.00 96.50           C  \\nATOM    705  OE1 GLU A  95       3.151  -9.457 -14.583  1.00 96.50           O  \\nATOM    706  OE2 GLU A  95       4.176  -7.698 -15.402  1.00 96.50           O  \\nATOM    707  N   VAL A  96       8.290  -9.973 -12.741  1.00 96.74           N  \\nATOM    708  CA  VAL A  96       8.850  -9.149 -11.684  1.00 96.74           C  \\nATOM    709  C   VAL A  96       8.930  -7.722 -12.195  1.00 96.74           C  \\nATOM    710  O   VAL A  96       9.514  -7.466 -13.246  1.00 96.74           O  \\nATOM    711  CB  VAL A  96      10.251  -9.619 -11.249  1.00 96.74           C  \\nATOM    712  CG1 VAL A  96      10.800  -8.709 -10.153  1.00 96.74           C  \\nATOM    713  CG2 VAL A  96      10.205 -11.070 -10.785  1.00 96.74           C  \\nATOM    714  N   ILE A  97       8.329  -6.805 -11.457  1.00 95.00           N  \\nATOM    715  CA  ILE A  97       8.338  -5.390 -11.797  1.00 95.00           C  \\nATOM    716  C   ILE A  97       8.970  -4.634 -10.644  1.00 95.00           C  \\nATOM    717  O   ILE A  97       8.534  -4.767  -9.499  1.00 95.00           O  \\nATOM    718  CB  ILE A  97       6.918  -4.857 -12.053  1.00 95.00           C  \\nATOM    719  CG1 ILE A  97       6.224  -5.674 -13.146  1.00 95.00           C  \\nATOM    720  CG2 ILE A  97       6.967  -3.375 -12.439  1.00 95.00           C  \\nATOM    721  CD1 ILE A  97       4.745  -5.362 -13.274  1.00 95.00           C  \\nATOM    722  N   GLU A  98      10.001  -3.844 -10.937  1.00 97.26           N  \\nATOM    723  CA  GLU A  98      10.619  -3.001  -9.927  1.00 97.26           C  \\nATOM    724  C   GLU A  98       9.958  -1.636  -9.931  1.00 97.26           C  \\nATOM    725  O   GLU A  98       9.790  -1.030 -10.984  1.00 97.26           O  \\nATOM    726  CB  GLU A  98      12.114  -2.840 -10.181  1.00 97.26           C  \\nATOM    727  CG  GLU A  98      12.918  -4.087  -9.892  1.00 97.26           C  \\nATOM    728  CD  GLU A  98      14.405  -3.806  -9.920  1.00 97.26           C  \\nATOM    729  OE1 GLU A  98      14.973  -3.752 -11.028  1.00 97.26           O  \\nATOM    730  OE2 GLU A  98      14.995  -3.619  -8.837  1.00 97.26           O  \\nATOM    731  N   LEU A  99       9.598  -1.157  -8.744  1.00 96.48           N  \\nATOM    732  CA  LEU A  99       8.853   0.085  -8.616  1.00 96.48           C  \\nATOM    733  C   LEU A  99       9.398   0.948  -7.500  1.00 96.48           C  \\nATOM    734  O   LEU A  99       9.839   0.449  -6.466  1.00 96.48           O  \\nATOM    735  CB  LEU A  99       7.379  -0.175  -8.293  1.00 96.48           C  \\nATOM    736  CG  LEU A  99       6.502  -0.880  -9.320  1.00 96.48           C  \\nATOM    737  CD1 LEU A  99       5.146  -1.159  -8.692  1.00 96.48           C  \\nATOM    738  CD2 LEU A  99       6.346  -0.032 -10.577  1.00 96.48           C  \\nATOM    739  N   GLU A 100       9.322   2.256  -7.701  1.00 98.03           N  \\nATOM    740  CA  GLU A 100       9.305   3.201  -6.609  1.00 98.03           C  \\nATOM    741  C   GLU A 100       7.845   3.541  -6.360  1.00 98.03           C  \\nATOM    742  O   GLU A 100       7.099   3.817  -7.300  1.00 98.03           O  \\nATOM    743  CB  GLU A 100      10.101   4.459  -6.947  1.00 98.03           C  \\nATOM    744  CG  GLU A 100      10.161   5.472  -5.820  1.00 98.03           C  \\nATOM    745  CD  GLU A 100      11.075   6.640  -6.139  1.00 98.03           C  \\nATOM    746  OE1 GLU A 100      10.754   7.417  -7.059  1.00 98.03           O  \\nATOM    747  OE2 GLU A 100      12.114   6.765  -5.471  1.00 98.03           O  \\nATOM    748  N   THR A 101       7.445   3.483  -5.105  1.00 98.26           N  \\nATOM    749  CA  THR A 101       6.045   3.702  -4.763  1.00 98.26           C  \\nATOM    750  C   THR A 101       5.931   4.842  -3.767  1.00 98.26           C  \\nATOM    751  O   THR A 101       6.859   5.131  -3.010  1.00 98.26           O  \\nATOM    752  CB  THR A 101       5.400   2.438  -4.173  1.00 98.26           C  \\nATOM    753  OG1 THR A 101       6.051   2.111  -2.937  1.00 98.26           O  \\nATOM    754  CG2 THR A 101       5.530   1.271  -5.139  1.00 98.26           C  \\nATOM    755  N   THR A 102       4.765   5.479  -3.781  1.00 98.37           N  \\nATOM    756  CA  THR A 102       4.480   6.594  -2.890  1.00 98.37           C  \\nATOM    757  C   THR A 102       3.091   6.417  -2.312  1.00 98.37           C  \\nATOM    758  O   THR A 102       2.161   6.041  -3.026  1.00 98.37           O  \\nATOM    759  CB  THR A 102       4.572   7.931  -3.638  1.00 98.37           C  \\nATOM    760  OG1 THR A 102       5.880   8.079  -4.208  1.00 98.37           O  \\nATOM    761  CG2 THR A 102       4.304   9.098  -2.699  1.00 98.37           C  \\nATOM    762  N   ALA A 103       2.960   6.681  -1.019  1.00 98.89           N  \\nATOM    763  CA  ALA A 103       1.665   6.679  -0.360  1.00 98.89           C  \\nATOM    764  C   ALA A 103       1.508   7.984   0.397  1.00 98.89           C  \\nATOM    765  O   ALA A 103       2.407   8.381   1.140  1.00 98.89           O  \\nATOM    766  CB  ALA A 103       1.531   5.500   0.597  1.00 98.89           C  \\nATOM    767  N   LYS A 104       0.386   8.638   0.198  1.00 98.93           N  \\nATOM    768  CA  LYS A 104       0.042   9.821   0.975  1.00 98.93           C  \\nATOM    769  C   LYS A 104      -0.949   9.423   2.051  1.00 98.93           C  \\nATOM    770  O   LYS A 104      -1.958   8.774   1.766  1.00 98.93           O  \\nATOM    771  CB  LYS A 104      -0.553  10.915   0.091  1.00 98.93           C  \\nATOM    772  CG  LYS A 104      -0.909  12.178   0.858  1.00 98.93           C  \\nATOM    773  CD  LYS A 104      -1.398  13.282  -0.062  1.00 98.93           C  \\nATOM    774  CE  LYS A 104      -1.725  14.548   0.715  1.00 98.93           C  \\nATOM    775  NZ  LYS A 104      -2.171  15.645  -0.187  1.00 98.93           N  \\nATOM    776  N   PHE A 105      -0.661   9.819   3.287  1.00 98.98           N  \\nATOM    777  CA  PHE A 105      -1.501   9.517   4.438  1.00 98.98           C  \\nATOM    778  C   PHE A 105      -2.149  10.790   4.956  1.00 98.98           C  \\nATOM    779  O   PHE A 105      -1.597  11.882   4.821  1.00 98.98           O  \\nATOM    780  CB  PHE A 105      -0.677   8.889   5.564  1.00 98.98           C  \\nATOM    781  CG  PHE A 105      -0.019   7.588   5.204  1.00 98.98           C  \\nATOM    782  CD1 PHE A 105       1.218   7.574   4.574  1.00 98.98           C  \\nATOM    783  CD2 PHE A 105      -0.618   6.380   5.504  1.00 98.98           C  \\nATOM    784  CE1 PHE A 105       1.842   6.381   4.252  1.00 98.98           C  \\nATOM    785  CE2 PHE A 105      -0.006   5.179   5.187  1.00 98.98           C  \\nATOM    786  CZ  PHE A 105       1.228   5.181   4.560  1.00 98.98           C  \\nATOM    787  N   VAL A 106      -3.310  10.629   5.560  1.00 98.84           N  \\nATOM    788  CA  VAL A 106      -3.984  11.724   6.241  1.00 98.84           C  \\nATOM    789  C   VAL A 106      -4.392  11.254   7.627  1.00 98.84           C  \\nATOM    790  O   VAL A 106      -4.767  10.094   7.815  1.00 98.84           O  \\nATOM    791  CB  VAL A 106      -5.216  12.242   5.468  1.00 98.84           C  \\nATOM    792  CG1 VAL A 106      -4.779  12.883   4.156  1.00 98.84           C  \\nATOM    793  CG2 VAL A 106      -6.215  11.121   5.218  1.00 98.84           C  \\nATOM    794  N   LEU A 107      -4.307  12.163   8.586  1.00 98.38           N  \\nATOM    795  CA  LEU A 107      -4.717  11.905   9.959  1.00 98.38           C  \\nATOM    796  C   LEU A 107      -6.046  12.596  10.200  1.00 98.38           C  \\nATOM    797  O   LEU A 107      -6.155  13.810  10.040  1.00 98.38           O  \\nATOM    798  CB  LEU A 107      -3.662  12.424  10.935  1.00 98.38           C  \\nATOM    799  CG  LEU A 107      -3.973  12.306  12.426  1.00 98.38           C  \\nATOM    800  CD1 LEU A 107      -4.034  10.851  12.850  1.00 98.38           C  \\nATOM    801  CD2 LEU A 107      -2.926  13.064  13.239  1.00 98.38           C  \\nATOM    802  N   VAL A 108      -7.054  11.812  10.565  1.00 96.88           N  \\nATOM    803  CA  VAL A 108      -8.388  12.337  10.811  1.00 96.88           C  \\nATOM    804  C   VAL A 108      -8.851  11.839  12.172  1.00 96.88           C  \\nATOM    805  O   VAL A 108      -9.014  10.634  12.373  1.00 96.88           O  \\nATOM    806  CB  VAL A 108      -9.388  11.899   9.723  1.00 96.88           C  \\nATOM    807  CG1 VAL A 108     -10.774  12.461  10.021  1.00 96.88           C  \\nATOM    808  CG2 VAL A 108      -8.902  12.333   8.349  1.00 96.88           C  \\nATOM    809  N   ASP A 109      -9.055  12.761  13.111  1.00 95.49           N  \\nATOM    810  CA  ASP A 109      -9.538  12.430  14.447  1.00 95.49           C  \\nATOM    811  C   ASP A 109      -8.717  11.319  15.087  1.00 95.49           C  \\nATOM    812  O   ASP A 109      -9.256  10.384  15.685  1.00 95.49           O  \\nATOM    813  CB  ASP A 109     -11.023  12.052  14.408  1.00 95.49           C  \\nATOM    814  CG  ASP A 109     -11.904  13.225  14.021  1.00 95.49           C  \\nATOM    815  OD1 ASP A 109     -11.545  14.376  14.340  1.00 95.49           O  \\nATOM    816  OD2 ASP A 109     -12.959  12.983  13.404  1.00 95.49           O  \\nATOM    817  N   GLY A 110      -7.400  11.413  14.937  1.00 96.31           N  \\nATOM    818  CA  GLY A 110      -6.506  10.474  15.586  1.00 96.31           C  \\nATOM    819  C   GLY A 110      -6.263   9.178  14.850  1.00 96.31           C  \\nATOM    820  O   GLY A 110      -5.503   8.336  15.340  1.00 96.31           O  \\nATOM    821  N   ARG A 111      -6.879   8.992  13.683  1.00 97.53           N  \\nATOM    822  CA  ARG A 111      -6.681   7.777  12.901  1.00 97.53           C  \\nATOM    823  C   ARG A 111      -6.058   8.113  11.559  1.00 97.53           C  \\nATOM    824  O   ARG A 111      -6.477   9.053  10.886  1.00 97.53           O  \\nATOM    825  CB  ARG A 111      -7.997   7.028  12.688  1.00 97.53           C  \\nATOM    826  CG  ARG A 111      -7.783   5.641  12.084  1.00 97.53           C  \\nATOM    827  CD  ARG A 111      -9.092   4.921  11.828  1.00 97.53           C  \\nATOM    828  NE  ARG A 111      -8.906   3.514  11.498  1.00 97.53           N  \\nATOM    829  CZ  ARG A 111      -8.505   3.046  10.322  1.00 97.53           C  \\nATOM    830  NH1 ARG A 111      -8.213   3.877   9.332  1.00 97.53           N  \\nATOM    831  NH2 ARG A 111      -8.381   1.737  10.130  1.00 97.53           N  \\nATOM    832  N   VAL A 112      -5.056   7.324  11.174  1.00 98.64           N  \\nATOM    833  CA  VAL A 112      -4.351   7.522   9.916  1.00 98.64           C  \\nATOM    834  C   VAL A 112      -5.007   6.680   8.828  1.00 98.64           C  \\nATOM    835  O   VAL A 112      -5.357   5.518   9.048  1.00 98.64           O  \\nATOM    836  CB  VAL A 112      -2.860   7.158  10.053  1.00 98.64           C  \\nATOM    837  CG1 VAL A 112      -2.146   7.284   8.718  1.00 98.64           C  \\nATOM    838  CG2 VAL A 112      -2.204   8.063  11.087  1.00 98.64           C  \\nATOM    839  N   TYR A 113      -5.178   7.272   7.655  1.00 98.98           N  \\nATOM    840  CA  TYR A 113      -5.706   6.600   6.476  1.00 98.98           C  \\nATOM    841  C   TYR A 113      -4.758   6.801   5.309  1.00 98.98           C  \\nATOM    842  O   TYR A 113      -4.007   7.771   5.265  1.00 98.98           O  \\nATOM    843  CB  TYR A 113      -7.070   7.170   6.079  1.00 98.98           C  \\nATOM    844  CG  TYR A 113      -8.144   7.003   7.116  1.00 98.98           C  \\nATOM    845  CD1 TYR A 113      -8.947   5.866   7.126  1.00 98.98           C  \\nATOM    846  CD2 TYR A 113      -8.369   7.978   8.075  1.00 98.98           C  \\nATOM    847  CE1 TYR A 113      -9.947   5.704   8.070  1.00 98.98           C  \\nATOM    848  CE2 TYR A 113      -9.366   7.828   9.027  1.00 98.98           C  \\nATOM    849  CZ  TYR A 113     -10.153   6.689   9.019  1.00 98.98           C  \\nATOM    850  OH  TYR A 113     -11.140   6.538   9.955  1.00 98.98           O  \\nATOM    851  N   ILE A 114      -4.831   5.896   4.337  1.00 98.98           N  \\nATOM    852  CA  ILE A 114      -4.122   6.064   3.079  1.00 98.98           C  \\nATOM    853  C   ILE A 114      -5.017   6.851   2.132  1.00 98.98           C  \\nATOM    854  O   ILE A 114      -6.131   6.432   1.815  1.00 98.98           O  \\nATOM    855  CB  ILE A 114      -3.733   4.712   2.462  1.00 98.98           C  \\nATOM    856  CG1 ILE A 114      -2.779   3.966   3.402  1.00 98.98           C  \\nATOM    857  CG2 ILE A 114      -3.097   4.920   1.091  1.00 98.98           C  \\nATOM    858  CD1 ILE A 114      -2.512   2.528   3.002  1.00 98.98           C  \\nATOM    859  N   LYS A 115      -4.521   7.991   1.689  1.00 98.90           N  \\nATOM    860  CA  LYS A 115      -5.257   8.875   0.796  1.00 98.90           C  \\nATOM    861  C   LYS A 115      -4.925   8.620  -0.668  1.00 98.90           C  \\nATOM    862  O   LYS A 115      -5.815   8.654  -1.529  1.00 98.90           O  \\nATOM    863  CB  LYS A 115      -4.952  10.331   1.160  1.00 98.90           C  \\nATOM    864  CG  LYS A 115      -5.457  11.369   0.187  1.00 98.90           C  \\nATOM    865  CD  LYS A 115      -6.960  11.486   0.197  1.00 98.90           C  \\nATOM    866  CE  LYS A 115      -7.391  12.669  -0.657  1.00 98.90           C  \\nATOM    867  NZ  LYS A 115      -8.861  12.796  -0.723  1.00 98.90           N  \\nATOM    868  N   LYS A 116      -3.655   8.381  -0.974  1.00 98.82           N  \\nATOM    869  CA  LYS A 116      -3.212   8.177  -2.348  1.00 98.82           C  \\nATOM    870  C   LYS A 116      -2.127   7.120  -2.391  1.00 98.82           C  \\nATOM    871  O   LYS A 116      -1.286   7.046  -1.497  1.00 98.82           O  \\nATOM    872  CB  LYS A 116      -2.657   9.473  -2.962  1.00 98.82           C  \\nATOM    873  CG  LYS A 116      -3.671  10.585  -3.094  1.00 98.82           C  \\nATOM    874  CD  LYS A 116      -3.087  11.794  -3.805  1.00 98.82           C  \\nATOM    875  CE  LYS A 116      -4.119  12.897  -3.956  1.00 98.82           C  \\nATOM    876  NZ  LYS A 116      -3.565  14.094  -4.642  1.00 98.82           N  \\nATOM    877  N   LEU A 117      -2.152   6.305  -3.439  1.00 98.85           N  \\nATOM    878  CA  LEU A 117      -1.118   5.320  -3.728  1.00 98.85           C  \\nATOM    879  C   LEU A 117      -0.644   5.535  -5.151  1.00 98.85           C  \\nATOM    880  O   LEU A 117      -1.452   5.799  -6.045  1.00 98.85           O  \\nATOM    881  CB  LEU A 117      -1.661   3.894  -3.590  1.00 98.85           C  \\nATOM    882  CG  LEU A 117      -2.103   3.453  -2.200  1.00 98.85           C  \\nATOM    883  CD1 LEU A 117      -3.013   2.235  -2.299  1.00 98.85           C  \\nATOM    884  CD2 LEU A 117      -0.887   3.139  -1.345  1.00 98.85           C  \\nATOM    885  N   GLU A 118       0.659   5.409  -5.372  1.00 97.95           N  \\nATOM    886  CA  GLU A 118       1.218   5.643  -6.693  1.00 97.95           C  \\nATOM    887  C   GLU A 118       2.431   4.763  -6.912  1.00 97.95           C  \\nATOM    888  O   GLU A 118       3.208   4.520  -5.988  1.00 97.95           O  \\nATOM    889  CB  GLU A 118       1.603   7.110  -6.861  1.00 97.95           C  \\nATOM    890  CG  GLU A 118       2.109   7.478  -8.241  1.00 97.95           C  \\nATOM    891  CD  GLU A 118       2.376   8.966  -8.391  1.00 97.95           C  \\nATOM    892  OE1 GLU A 118       2.444   9.672  -7.358  1.00 97.95           O  \\nATOM    893  OE2 GLU A 118       2.519   9.424  -9.543  1.00 97.95           O  \\nATOM    894  N   GLY A 119       2.595   4.299  -8.145  1.00 98.18           N  \\nATOM    895  CA  GLY A 119       3.754   3.512  -8.519  1.00 98.18           C  \\nATOM    896  C   GLY A 119       4.439   4.079  -9.740  1.00 98.18           C  \\nATOM    897  O   GLY A 119       3.788   4.607 -10.643  1.00 98.18           O  \\nATOM    898  N   LYS A 120       5.744   3.978  -9.765  1.00 97.57           N  \\nATOM    899  CA  LYS A 120       6.550   4.392 -10.907  1.00 97.57           C  \\nATOM    900  C   LYS A 120       7.563   3.298 -11.184  1.00 97.57           C  \\nATOM    901  O   LYS A 120       8.385   2.974 -10.330  1.00 97.57           O  \\nATOM    902  CB  LYS A 120       7.263   5.714 -10.630  1.00 97.57           C  \\nATOM    903  CG  LYS A 120       8.152   6.179 -11.761  1.00 97.57           C  \\nATOM    904  CD  LYS A 120       8.635   7.605 -11.562  1.00 97.57           C  \\nATOM    905  CE  LYS A 120       9.585   7.721 -10.393  1.00 97.57           C  \\nATOM    906  NZ  LYS A 120      10.118   9.106 -10.252  1.00 97.57           N  \\nATOM    907  N   GLU A 121       7.519   2.700 -12.382  1.00 95.37           N  \\nATOM    908  CA  GLU A 121       8.407   1.605 -12.720  1.00 95.37           C  \\nATOM    909  C   GLU A 121       9.838   2.099 -12.856  1.00 95.37           C  \\nATOM    910  O   GLU A 121      10.085   3.167 -13.415  1.00 95.37           O  \\nATOM    911  CB  GLU A 121       7.951   0.923 -14.006  1.00 95.37           C  \\nATOM    912  CG  GLU A 121       8.638  -0.395 -14.271  1.00 95.37           C  \\nATOM    913  CD  GLU A 121       7.963  -1.213 -15.362  1.00 95.37           C  \\nATOM    914  OE1 GLU A 121       6.828  -0.866 -15.762  1.00 95.37           O  \\nATOM    915  OE2 GLU A 121       8.565  -2.205 -15.807  1.00 95.37           O  \\nATOM    916  N   LEU A 122      10.758   1.324 -12.330  1.00 94.26           N  \\nATOM    917  CA  LEU A 122      12.174   1.650 -12.396  1.00 94.26           C  \\nATOM    918  C   LEU A 122      12.806   0.986 -13.610  1.00 94.26           C  \\nATOM    919  O   LEU A 122      12.386  -0.105 -14.010  1.00 94.26           O  \\nATOM    920  CB  LEU A 122      12.886   1.193 -11.122  1.00 94.26           C  \\nATOM    921  CG  LEU A 122      12.423   1.862  -9.833  1.00 94.26           C  \\nATOM    922  CD1 LEU A 122      13.087   1.210  -8.630  1.00 94.26           C  \\nATOM    923  CD2 LEU A 122      12.712   3.356  -9.868  1.00 94.26           C  \\nATOM    924  N   PRO A 123      13.832   1.644 -14.180  1.00 83.76           N  \\nATOM    925  CA  PRO A 123      14.506   1.042 -15.330  1.00 83.76           C  \\nATOM    926  C   PRO A 123      15.345  -0.170 -14.952  1.00 83.76           C  \\nATOM    927  O   PRO A 123      15.651  -0.373 -13.769  1.00 83.76           O  \\nATOM    928  CB  PRO A 123      15.388   2.181 -15.847  1.00 83.76           C  \\nATOM    929  CG  PRO A 123      15.642   3.023 -14.650  1.00 83.76           C  \\nATOM    930  CD  PRO A 123      14.396   2.955 -13.819  1.00 83.76           C  \\nTER     931      PRO A 123                                                      \\nHETATM  932  C1  LIG B   1      -1.253  -8.310  -4.581  1.00  0.00           C  \\nHETATM  933  O1  LIG B   1      -1.846  -7.588  -5.644  1.00  0.00           O  \\nHETATM  934  C2  LIG B   1      -1.274  -6.452  -6.112  1.00  0.00           C  \\nHETATM  935  C3  LIG B   1      -2.090  -5.525  -6.767  1.00  0.00           C  \\nHETATM  936  C4  LIG B   1      -1.531  -4.361  -7.278  1.00  0.00           C  \\nHETATM  937  C5  LIG B   1      -0.173  -4.111  -7.157  1.00  0.00           C  \\nHETATM  938  N1  LIG B   1       0.349  -2.969  -7.755  1.00  0.00           N  \\nHETATM  939  N2  LIG B   1       0.407  -2.888  -9.082  1.00  0.00           N  \\nHETATM  940  C6  LIG B   1       0.933  -1.717  -9.422  1.00  0.00           C  \\nHETATM  941  C7  LIG B   1       1.147  -1.281 -10.811  1.00  0.00           C  \\nHETATM  942  N3  LIG B   1       0.798  -2.179 -11.773  1.00  0.00           N  \\nHETATM  943  O2  LIG B   1       1.625  -0.171 -11.066  1.00  0.00           O  \\nHETATM  944  C8  LIG B   1       1.224  -1.000  -8.245  1.00  0.00           C  \\nHETATM  945  C9  LIG B   1       0.843  -1.805  -7.213  1.00  0.00           C  \\nHETATM  946  C10 LIG B   1       1.018  -1.397  -5.833  1.00  0.00           C  \\nHETATM  947  O3  LIG B   1       0.601  -2.119  -4.899  1.00  0.00           O  \\nHETATM  948  N4  LIG B   1       1.682  -0.199  -5.569  1.00  0.00           N  \\nHETATM  949  C11 LIG B   1       1.999   0.255  -4.257  1.00  0.00           C  \\nHETATM  950  C12 LIG B   1       1.713   1.554  -3.855  1.00  0.00           C  \\nHETATM  951  C13 LIG B   1       2.051   2.002  -2.559  1.00  0.00           C  \\nHETATM  952  C14 LIG B   1       2.677   1.157  -1.657  1.00  0.00           C  \\nHETATM  953  N5  LIG B   1       3.032   1.585  -0.377  1.00  0.00           N  \\nHETATM  954  C15 LIG B   1       2.390   0.906   0.735  1.00  0.00           C  \\nHETATM  955  C16 LIG B   1       3.116   0.986   2.030  1.00  0.00           C  \\nHETATM  956  C17 LIG B   1       3.469   2.428   2.326  1.00  0.00           C  \\nHETATM  957  C18 LIG B   1       4.386   2.960   1.250  1.00  0.00           C  \\nHETATM  958  C19 LIG B   1       3.939   2.612  -0.148  1.00  0.00           C  \\nHETATM  959  O4  LIG B   1       4.438   3.228  -1.076  1.00  0.00           O  \\nHETATM  960  C20 LIG B   1       2.967  -0.152  -2.063  1.00  0.00           C  \\nHETATM  961  C21 LIG B   1       2.640  -0.592  -3.359  1.00  0.00           C  \\nHETATM  962  C22 LIG B   1       2.188   0.620  -6.629  1.00  0.00           C  \\nHETATM  963  C23 LIG B   1       1.799   0.341  -8.019  1.00  0.00           C  \\nHETATM  964  C24 LIG B   1       0.631  -5.046  -6.511  1.00  0.00           C  \\nHETATM  965  C25 LIG B   1       0.087  -6.226  -5.977  1.00  0.00           C  \\nHETATM  966  H1  LIG B   1      -1.594  -7.895  -3.621  1.00  0.00           H  \\nHETATM  967  H2  LIG B   1      -1.546  -9.368  -4.648  1.00  0.00           H  \\nHETATM  968  H3  LIG B   1      -0.158  -8.228  -4.648  1.00  0.00           H  \\nHETATM  969  H4  LIG B   1      -3.168  -5.716  -6.877  1.00  0.00           H  \\nHETATM  970  H5  LIG B   1      -2.175  -3.627  -7.786  1.00  0.00           H  \\nHETATM  971  H6  LIG B   1       0.920  -1.942 -12.768  1.00  0.00           H  \\nHETATM  972  H7  LIG B   1       0.412  -3.096 -11.506  1.00  0.00           H  \\nHETATM  973  H8  LIG B   1       1.217   2.242  -4.555  1.00  0.00           H  \\nHETATM  974  H9  LIG B   1       1.814   3.034  -2.262  1.00  0.00           H  \\nHETATM  975  H10 LIG B   1       1.394   1.350   0.875  1.00  0.00           H  \\nHETATM  976  H11 LIG B   1       2.362  -0.160   0.466  1.00  0.00           H  \\nHETATM  977  H12 LIG B   1       2.476   0.594   2.834  1.00  0.00           H  \\nHETATM  978  H13 LIG B   1       4.038   0.389   1.969  1.00  0.00           H  \\nHETATM  979  H14 LIG B   1       2.549   3.031   2.354  1.00  0.00           H  \\nHETATM  980  H15 LIG B   1       3.978   2.485   3.299  1.00  0.00           H  \\nHETATM  981  H16 LIG B   1       4.429   4.056   1.339  1.00  0.00           H  \\nHETATM  982  H17 LIG B   1       5.369   2.490   1.402  1.00  0.00           H  \\nHETATM  983  H18 LIG B   1       3.456  -0.844  -1.361  1.00  0.00           H  \\nHETATM  984  H19 LIG B   1       2.894  -1.617  -3.665  1.00  0.00           H  \\nHETATM  985  H20 LIG B   1       1.874   1.652  -6.412  1.00  0.00           H  \\nHETATM  986  H21 LIG B   1       3.268   0.410  -6.620  1.00  0.00           H  \\nHETATM  987  H22 LIG B   1       1.051   1.089  -8.322  1.00  0.00           H  \\nHETATM  988  H23 LIG B   1       2.723   0.385  -8.614  1.00  0.00           H  \\nHETATM  989  H24 LIG B   1       1.711  -4.858  -6.417  1.00  0.00           H  \\nHETATM  990  H25 LIG B   1       0.728  -6.956  -5.462  1.00  0.00           H  \\nCONECT  932  933  966  967  968\\nCONECT  933  932  934\\nCONECT  934  933  935  965\\nCONECT  935  934  936  969\\nCONECT  936  935  937  970\\nCONECT  937  936  938  964\\nCONECT  938  937  939  945\\nCONECT  939  938  940\\nCONECT  940  939  941  944\\nCONECT  941  940  942  943\\nCONECT  942  941  971  972\\nCONECT  943  941\\nCONECT  944  940  945  963\\nCONECT  945  938  944  946\\nCONECT  946  945  947  948\\nCONECT  947  946\\nCONECT  948  946  949  962\\nCONECT  949  948  950  961\\nCONECT  950  949  951  973\\nCONECT  951  950  952  974\\nCONECT  952  951  953  960\\nCONECT  953  952  954  958\\nCONECT  954  953  955  975  976\\nCONECT  955  954  956  977  978\\nCONECT  956  955  957  979  980\\nCONECT  957  956  958  981  982\\nCONECT  958  953  957  959\\nCONECT  959  958\\nCONECT  960  952  961  983\\nCONECT  961  949  960  984\\nCONECT  962  948  963  985  986\\nCONECT  963  944  962  987  988\\nCONECT  964  937  965  989\\nCONECT  965  934  964  990\\nCONECT  966  932\\nCONECT  967  932\\nCONECT  968  932\\nCONECT  969  935\\nCONECT  970  936\\nCONECT  971  942\\nCONECT  972  942\\nCONECT  973  950\\nCONECT  974  951\\nCONECT  975  954\\nCONECT  976  954\\nCONECT  977  955\\nCONECT  978  955\\nCONECT  979  956\\nCONECT  980  956\\nCONECT  981  957\\nCONECT  982  957\\nCONECT  983  960\\nCONECT  984  961\\nCONECT  985  962\\nCONECT  986  962\\nCONECT  987  963\\nCONECT  988  963\\nCONECT  989  964\\nCONECT  990  965\",\"pdb\");\n\tviewer_17690125233949301.setBackgroundColor(\"black\");\n\tviewer_17690125233949301.setStyle({},{});\n\tviewer_17690125233949301.setStyle({\"chain\": \"A\"},{\"cartoon\": {\"colorscheme\": \"greenCarbon\"}, \"stick\": {\"colorscheme\": \"greenCarbon\"}});\n\tviewer_17690125233949301.setStyle({\"chain\": \"B\"},{\"stick\": {\"colorscheme\": \"cyanCarbon\"}});\n\tviewer_17690125233949301.zoomTo();\nviewer_17690125233949301.render();\n});\n</script>",
             "text/html": [
@@ -528,21 +486,78 @@
               "</script>"
             ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "# @title ### Visualize input structure\n",
+        "import py3Dmol\n",
+        "\n",
+        "view = py3Dmol.view(width=1000)\n",
+        "view.addModel(open('./nise_trajectory/input_backbones/input.pdb', 'r').read(), 'pdb', keepH=True)\n",
+        "\n",
+        "view.setBackgroundColor('black')\n",
+        "view.setStyle({}, {})  # clear default\n",
+        "\n",
+        "# Chain A: cartoon + sticks with green carbons, other elements by element color\n",
+        "view.setStyle({'chain': 'A'}, {\n",
+        "    'cartoon': {'colorscheme': 'greenCarbon'},\n",
+        "    'stick': {'colorscheme': 'greenCarbon'}\n",
+        "})\n",
+        "\n",
+        "# Chain B: sticks with cyan carbons, other elements by element color\n",
+        "view.setStyle({'chain': 'B'}, {\n",
+        "    'stick': {'colorscheme': 'cyanCarbon'}\n",
+        "})\n",
+        "\n",
+        "view.zoomTo()\n",
+        "view.show()"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Sanity check the inputs."
-      ],
       "metadata": {
         "id": "xihJoMVDOTJS"
-      }
+      },
+      "source": [
+        "### Sanity check the inputs."
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 15,
+      "metadata": {
+        "cellView": "form",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "bv7qTaFQOSLF",
+        "outputId": "88d22310-fc99-4f7b-8601-0b2791e4f7fb"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Running input checks...\n",
+            "✅ - the input PDB file has exactly two chains.\n",
+            "✅ - the input PDB file has chains A and B.\n",
+            "✅ - the ligand is on chain B and parseable by RDkit.\n",
+            "✅ - the smiles string provided by the user can be parsed by RDkit.\n",
+            "✅ - the smiles string matches the ligand in the PDB file.\n",
+            "✅ - the input PDB file has 25 hydrogen atoms on the ligand and the smiles string encodes 25 hydrogen atoms.\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "[16:22:05] WARNING: More than one matching pattern found - picking one\n",
+            "\n"
+          ]
+        }
+      ],
       "source": [
         "import traceback\n",
         "import io\n",
@@ -634,51 +649,25 @@
         "  print(f'✅ - The input PDB file ({ipath}) has been modified and now has {num_ligand_hydrogens} hydrogen atoms on the ligand.')\n",
         "else:\n",
         "  raise ValueError(f'🟨 - The input file has {num_ligand_hydrogens} hydrogens and your smiles string encodes {num_expected_hs} hydrogens, but you opted to not reprotonate the ligand. This may impact the quality of the sequence generated by LASErMPNN in the first NISE iteration, though sampled backbones fed into LASErMPNN in future iterations will be properly protonated.')\n"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "bv7qTaFQOSLF",
-        "outputId": "88d22310-fc99-4f7b-8601-0b2791e4f7fb",
-        "cellView": "form"
-      },
-      "execution_count": 15,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Running input checks...\n",
-            "✅ - the input PDB file has exactly two chains.\n",
-            "✅ - the input PDB file has chains A and B.\n",
-            "✅ - the ligand is on chain B and parseable by RDkit.\n",
-            "✅ - the smiles string provided by the user can be parsed by RDkit.\n",
-            "✅ - the smiles string matches the ligand in the PDB file.\n",
-            "✅ - the input PDB file has 25 hydrogen atoms on the ligand and the smiles string encodes 25 hydrogen atoms.\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "[16:22:05] WARNING: More than one matching pattern found - picking one\n",
-            "\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Configure NISE"
-      ],
       "metadata": {
         "id": "aqmROt2Ohn1J"
-      }
+      },
+      "source": [
+        "### Configure NISE"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 16,
+      "metadata": {
+        "cellView": "form",
+        "id": "2pw9KW2Odgxl"
+      },
+      "outputs": [],
       "source": [
         "%%capture\n",
         "\n",
@@ -831,32 +820,22 @@
         "\n",
         "with open('run_nise_boltz2x.py', 'w') as f:\n",
         "  f.write('\\n'.join(lines_split))"
-      ],
-      "metadata": {
-        "id": "2pw9KW2Odgxl",
-        "cellView": "form"
-      },
-      "execution_count": 16,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# @title # Run NISE\n",
-        "!./.venv/bin/python run_nise_boltz2x.py"
-      ],
+      "execution_count": 17,
       "metadata": {
-        "id": "JA0s1FcEh3n9",
-        "outputId": "c4159184-699c-4a09-c0a9-0ad3216e202e",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "JA0s1FcEh3n9",
+        "outputId": "c4159184-699c-4a09-c0a9-0ad3216e202e"
       },
-      "execution_count": 17,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "CUDA_VISIBLE_DEVICES=0 /content/.venv/bin/boltz predict /content/nise_trajectory/sampled_backbones/iter_0/boltz_inputs --devices 1 --out_dir /content/nise_trajectory/sampled_backbones/iter_0 --output_format pdb --override --sampling_steps 50 --sampling_steps_affinity 50 --cache /content/drive/MyDrive/boltz/\n",
             "(PosixPath('/content/nise_trajectory/input_backbones/input.pdb'), 1.9634071295008937)\n",
@@ -894,10 +873,65 @@
             "{'min_protein_rmsd': 0.23811445449035087, 'min_ligand_rmsd': 0.1794963238051016, 'mean_sampled_ligand_plddt': 0.801871875, 'mean_sampled_protein_plddt': 0.8804566565040651, 'mean_sampled_protein_rmsd': 3.020837165394311, 'mean_sampled_ligand_rmsd': 3.140465679117246, 'num_sequences_sampled': 16, 'mean_affinity_probability': nan, 'mean_affinity_pred_value': nan, 'mean_iptm': 0.8741270154714584, 'mean_laser_score': 0.27382794, 'mean_laser_bs_score': 0.11927669, 'max_sampled_backbone_priority': 1.9685876407847682}\n"
           ]
         }
+      ],
+      "source": [
+        "# @title # Run NISE\n",
+        "!./.venv/bin/python run_nise_boltz2x.py"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 24,
+      "metadata": {
+        "cellView": "form",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 542
+        },
+        "id": "4lnm4d8EOt0A",
+        "outputId": "82fdf6df-01ed-4e7b-c45f-85322504f854"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<html>\n",
+              "<head><meta charset=\"utf-8\" /></head>\n",
+              "<body>\n",
+              "    <div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax && window.MathJax.Hub && window.MathJax.Hub.Config) {window.MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
+              "        <script charset=\"utf-8\" src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script>                <div id=\"9bc980ca-a0c3-469b-ab7d-93c497040d70\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"9bc980ca-a0c3-469b-ab7d-93c497040d70\")) {                    Plotly.newPlot(                        \"9bc980ca-a0c3-469b-ab7d-93c497040d70\",                        [{\"customdata\":[[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_0\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_1\\u002fchunk_0_seq_1_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_0\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_1\\u002fchunk_0_seq_1_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_2\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_2\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_2\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_2\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_2\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_7\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_8\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_14\\u002fchunk_0_seq_14_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_8\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_14\\u002fchunk_0_seq_14_model_0.pdb\"]],\"hovertemplate\":\"Backbone Rank=0\\u003cbr\\u003enise_iter=%{x}\\u003cbr\\u003eScore (ligand_plddt_and_iptm)=%{y}\\u003cbr\\u003epath=%{customdata[0]}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"legendgroup\":\"0\",\"line\":{\"color\":\"#636efa\",\"dash\":\"solid\"},\"marker\":{\"symbol\":\"circle\",\"size\":10},\"mode\":\"lines+markers\",\"name\":\"0\",\"orientation\":\"h\",\"showlegend\":true,\"x\":[0,1,2,3,4,5,6,7,8,9],\"xaxis\":\"x\",\"y\":[1.9634071295008937,1.9634071295008937,1.9650295657157897,1.9650295657157897,1.9650295657157897,1.9650295657157897,1.9650295657157897,1.965437535459855,1.9685876407847682,1.9685876407847682],\"yaxis\":\"y\",\"type\":\"scatter\"},{\"customdata\":[[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_0\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_2\\u002fchunk_0_seq_2_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_1\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_4\\u002fchunk_0_seq_4_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_0\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_1\\u002fchunk_0_seq_1_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_3\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_12\\u002fchunk_0_seq_12_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_3\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_12\\u002fchunk_0_seq_12_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_3\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_12\\u002fchunk_0_seq_12_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_3\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_12\\u002fchunk_0_seq_12_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_2\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_8\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_2\\u002fchunk_0_seq_2_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_8\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_2\\u002fchunk_0_seq_2_model_0.pdb\"]],\"hovertemplate\":\"Backbone Rank=1\\u003cbr\\u003enise_iter=%{x}\\u003cbr\\u003eScore (ligand_plddt_and_iptm)=%{y}\\u003cbr\\u003epath=%{customdata[0]}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"legendgroup\":\"1\",\"line\":{\"color\":\"#EF553B\",\"dash\":\"solid\"},\"marker\":{\"symbol\":\"circle\",\"size\":10},\"mode\":\"lines+markers\",\"name\":\"1\",\"orientation\":\"h\",\"showlegend\":true,\"x\":[0,1,2,3,4,5,6,7,8,9],\"xaxis\":\"x\",\"y\":[1.95269457320606,1.9569753101404974,1.9634071295008937,1.9637369299327627,1.9637369299327627,1.9637369299327627,1.9637369299327627,1.9650295657157897,1.968204917683321,1.968204917683321],\"yaxis\":\"y\",\"type\":\"scatter\"},{\"customdata\":[[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_0\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_3\\u002fchunk_0_seq_3_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_1\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_14\\u002fchunk_0_seq_14_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_2\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_2\\u002fchunk_0_seq_2_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_0\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_1\\u002fchunk_0_seq_1_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_0\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_1\\u002fchunk_0_seq_1_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_0\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_1\\u002fchunk_0_seq_1_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_6\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_1\\u002fchunk_0_seq_1_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_3\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_12\\u002fchunk_0_seq_12_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_7\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_7\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"]],\"hovertemplate\":\"Backbone Rank=2\\u003cbr\\u003enise_iter=%{x}\\u003cbr\\u003eScore (ligand_plddt_and_iptm)=%{y}\\u003cbr\\u003epath=%{customdata[0]}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"legendgroup\":\"2\",\"line\":{\"color\":\"#00cc96\",\"dash\":\"solid\"},\"marker\":{\"symbol\":\"circle\",\"size\":10},\"mode\":\"lines+markers\",\"name\":\"2\",\"orientation\":\"h\",\"showlegend\":true,\"x\":[0,1,2,3,4,5,6,7,8,9],\"xaxis\":\"x\",\"y\":[1.9403027241426356,1.956210267201592,1.9632497516800376,1.9634071295008937,1.9634071295008937,1.9634071295008937,1.9637079877180212,1.9637369299327627,1.965437535459855,1.965437535459855],\"yaxis\":\"y\",\"type\":\"scatter\"}],                        {\"template\":{\"data\":{\"histogram2dcontour\":[{\"type\":\"histogram2dcontour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"choropleth\":[{\"type\":\"choropleth\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"histogram2d\":[{\"type\":\"histogram2d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmap\":[{\"type\":\"heatmap\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmapgl\":[{\"type\":\"heatmapgl\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"contourcarpet\":[{\"type\":\"contourcarpet\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"contour\":[{\"type\":\"contour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"surface\":[{\"type\":\"surface\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"mesh3d\":[{\"type\":\"mesh3d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"parcoords\":[{\"type\":\"parcoords\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolargl\":[{\"type\":\"scatterpolargl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"scattergeo\":[{\"type\":\"scattergeo\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolar\":[{\"type\":\"scatterpolar\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"scattergl\":[{\"type\":\"scattergl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatter3d\":[{\"type\":\"scatter3d\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattermapbox\":[{\"type\":\"scattermapbox\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterternary\":[{\"type\":\"scatterternary\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattercarpet\":[{\"type\":\"scattercarpet\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}]},\"layout\":{\"autotypenumbers\":\"strict\",\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"hovermode\":\"closest\",\"hoverlabel\":{\"align\":\"left\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"bgcolor\":\"#E5ECF6\",\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"ternary\":{\"bgcolor\":\"#E5ECF6\",\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]]},\"xaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"yaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"geo\":{\"bgcolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"subunitcolor\":\"white\",\"showland\":true,\"showlakes\":true,\"lakecolor\":\"white\"},\"title\":{\"x\":0.05},\"mapbox\":{\"style\":\"light\"}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"nise_iter\"}},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"score\"}},\"legend\":{\"title\":{\"text\":\"Backbone Rank\"},\"tracegroupgap\":0},\"title\":{\"text\":\"Sampled Backbone Scores per NISE Iteration\"},\"font\":{\"size\":24}},                        {\"responsive\": true}                    ).then(function(){\n",
+              "                            \n",
+              "var gd = document.getElementById('9bc980ca-a0c3-469b-ab7d-93c497040d70');\n",
+              "var x = new MutationObserver(function (mutations, observer) {{\n",
+              "        var display = window.getComputedStyle(gd).display;\n",
+              "        if (!display || display === 'none') {{\n",
+              "            console.log([gd, 'removed!']);\n",
+              "            Plotly.purge(gd);\n",
+              "            observer.disconnect();\n",
+              "        }}\n",
+              "}});\n",
+              "\n",
+              "// Listen for the removal of the full notebook cells\n",
+              "var notebookContainer = gd.closest('#notebook-container');\n",
+              "if (notebookContainer) {{\n",
+              "    x.observe(notebookContainer, {childList: true});\n",
+              "}}\n",
+              "\n",
+              "// Listen for the clearing of the current output cell\n",
+              "var outputEl = gd.closest('.output');\n",
+              "if (outputEl) {{\n",
+              "    x.observe(outputEl, {childList: true});\n",
+              "}}\n",
+              "\n",
+              "                        })                };                            </script>        </div>\n",
+              "</body>\n",
+              "</html>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
       "source": [
         "# @title Visualize trajectory\n",
         "\n",
@@ -958,61 +992,42 @@
         "\n",
         "\n",
         "fig.show()\n"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 542
-        },
-        "cellView": "form",
-        "id": "4lnm4d8EOt0A",
-        "outputId": "82fdf6df-01ed-4e7b-c45f-85322504f854"
-      },
-      "execution_count": 24,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/html": [
-              "<html>\n",
-              "<head><meta charset=\"utf-8\" /></head>\n",
-              "<body>\n",
-              "    <div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax && window.MathJax.Hub && window.MathJax.Hub.Config) {window.MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
-              "        <script charset=\"utf-8\" src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script>                <div id=\"9bc980ca-a0c3-469b-ab7d-93c497040d70\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"9bc980ca-a0c3-469b-ab7d-93c497040d70\")) {                    Plotly.newPlot(                        \"9bc980ca-a0c3-469b-ab7d-93c497040d70\",                        [{\"customdata\":[[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_0\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_1\\u002fchunk_0_seq_1_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_0\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_1\\u002fchunk_0_seq_1_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_2\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_2\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_2\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_2\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_2\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_7\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_8\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_14\\u002fchunk_0_seq_14_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_8\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_14\\u002fchunk_0_seq_14_model_0.pdb\"]],\"hovertemplate\":\"Backbone Rank=0\\u003cbr\\u003enise_iter=%{x}\\u003cbr\\u003eScore (ligand_plddt_and_iptm)=%{y}\\u003cbr\\u003epath=%{customdata[0]}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"legendgroup\":\"0\",\"line\":{\"color\":\"#636efa\",\"dash\":\"solid\"},\"marker\":{\"symbol\":\"circle\",\"size\":10},\"mode\":\"lines+markers\",\"name\":\"0\",\"orientation\":\"h\",\"showlegend\":true,\"x\":[0,1,2,3,4,5,6,7,8,9],\"xaxis\":\"x\",\"y\":[1.9634071295008937,1.9634071295008937,1.9650295657157897,1.9650295657157897,1.9650295657157897,1.9650295657157897,1.9650295657157897,1.965437535459855,1.9685876407847682,1.9685876407847682],\"yaxis\":\"y\",\"type\":\"scatter\"},{\"customdata\":[[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_0\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_2\\u002fchunk_0_seq_2_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_1\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_4\\u002fchunk_0_seq_4_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_0\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_1\\u002fchunk_0_seq_1_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_3\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_12\\u002fchunk_0_seq_12_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_3\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_12\\u002fchunk_0_seq_12_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_3\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_12\\u002fchunk_0_seq_12_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_3\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_12\\u002fchunk_0_seq_12_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_2\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_8\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_2\\u002fchunk_0_seq_2_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_8\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_2\\u002fchunk_0_seq_2_model_0.pdb\"]],\"hovertemplate\":\"Backbone Rank=1\\u003cbr\\u003enise_iter=%{x}\\u003cbr\\u003eScore (ligand_plddt_and_iptm)=%{y}\\u003cbr\\u003epath=%{customdata[0]}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"legendgroup\":\"1\",\"line\":{\"color\":\"#EF553B\",\"dash\":\"solid\"},\"marker\":{\"symbol\":\"circle\",\"size\":10},\"mode\":\"lines+markers\",\"name\":\"1\",\"orientation\":\"h\",\"showlegend\":true,\"x\":[0,1,2,3,4,5,6,7,8,9],\"xaxis\":\"x\",\"y\":[1.95269457320606,1.9569753101404974,1.9634071295008937,1.9637369299327627,1.9637369299327627,1.9637369299327627,1.9637369299327627,1.9650295657157897,1.968204917683321,1.968204917683321],\"yaxis\":\"y\",\"type\":\"scatter\"},{\"customdata\":[[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_0\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_3\\u002fchunk_0_seq_3_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_1\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_14\\u002fchunk_0_seq_14_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_2\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_2\\u002fchunk_0_seq_2_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_0\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_1\\u002fchunk_0_seq_1_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_0\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_1\\u002fchunk_0_seq_1_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_0\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_1\\u002fchunk_0_seq_1_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_6\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_1\\u002fchunk_0_seq_1_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_3\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_12\\u002fchunk_0_seq_12_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_7\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"],[\"\\u002fcontent\\u002fnise_trajectory\\u002fsampled_backbones\\u002fiter_7\\u002fboltz_results_boltz_inputs\\u002fpredictions\\u002fchunk_0_seq_6\\u002fchunk_0_seq_6_model_0.pdb\"]],\"hovertemplate\":\"Backbone Rank=2\\u003cbr\\u003enise_iter=%{x}\\u003cbr\\u003eScore (ligand_plddt_and_iptm)=%{y}\\u003cbr\\u003epath=%{customdata[0]}\\u003cextra\\u003e\\u003c\\u002fextra\\u003e\",\"legendgroup\":\"2\",\"line\":{\"color\":\"#00cc96\",\"dash\":\"solid\"},\"marker\":{\"symbol\":\"circle\",\"size\":10},\"mode\":\"lines+markers\",\"name\":\"2\",\"orientation\":\"h\",\"showlegend\":true,\"x\":[0,1,2,3,4,5,6,7,8,9],\"xaxis\":\"x\",\"y\":[1.9403027241426356,1.956210267201592,1.9632497516800376,1.9634071295008937,1.9634071295008937,1.9634071295008937,1.9637079877180212,1.9637369299327627,1.965437535459855,1.965437535459855],\"yaxis\":\"y\",\"type\":\"scatter\"}],                        {\"template\":{\"data\":{\"histogram2dcontour\":[{\"type\":\"histogram2dcontour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"choropleth\":[{\"type\":\"choropleth\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"histogram2d\":[{\"type\":\"histogram2d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmap\":[{\"type\":\"heatmap\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmapgl\":[{\"type\":\"heatmapgl\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"contourcarpet\":[{\"type\":\"contourcarpet\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"contour\":[{\"type\":\"contour\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"surface\":[{\"type\":\"surface\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"mesh3d\":[{\"type\":\"mesh3d\",\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}],\"scatter\":[{\"fillpattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2},\"type\":\"scatter\"}],\"parcoords\":[{\"type\":\"parcoords\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolargl\":[{\"type\":\"scatterpolargl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"scattergeo\":[{\"type\":\"scattergeo\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterpolar\":[{\"type\":\"scatterpolar\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"scattergl\":[{\"type\":\"scattergl\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatter3d\":[{\"type\":\"scatter3d\",\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattermapbox\":[{\"type\":\"scattermapbox\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scatterternary\":[{\"type\":\"scatterternary\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"scattercarpet\":[{\"type\":\"scattercarpet\",\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}}}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}]},\"layout\":{\"autotypenumbers\":\"strict\",\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"hovermode\":\"closest\",\"hoverlabel\":{\"align\":\"left\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"bgcolor\":\"#E5ECF6\",\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"ternary\":{\"bgcolor\":\"#E5ECF6\",\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]]},\"xaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"yaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"automargin\":true,\"zerolinewidth\":2},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\",\"gridwidth\":2}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"geo\":{\"bgcolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"subunitcolor\":\"white\",\"showland\":true,\"showlakes\":true,\"lakecolor\":\"white\"},\"title\":{\"x\":0.05},\"mapbox\":{\"style\":\"light\"}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"nise_iter\"}},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.0,1.0],\"title\":{\"text\":\"score\"}},\"legend\":{\"title\":{\"text\":\"Backbone Rank\"},\"tracegroupgap\":0},\"title\":{\"text\":\"Sampled Backbone Scores per NISE Iteration\"},\"font\":{\"size\":24}},                        {\"responsive\": true}                    ).then(function(){\n",
-              "                            \n",
-              "var gd = document.getElementById('9bc980ca-a0c3-469b-ab7d-93c497040d70');\n",
-              "var x = new MutationObserver(function (mutations, observer) {{\n",
-              "        var display = window.getComputedStyle(gd).display;\n",
-              "        if (!display || display === 'none') {{\n",
-              "            console.log([gd, 'removed!']);\n",
-              "            Plotly.purge(gd);\n",
-              "            observer.disconnect();\n",
-              "        }}\n",
-              "}});\n",
-              "\n",
-              "// Listen for the removal of the full notebook cells\n",
-              "var notebookContainer = gd.closest('#notebook-container');\n",
-              "if (notebookContainer) {{\n",
-              "    x.observe(notebookContainer, {childList: true});\n",
-              "}}\n",
-              "\n",
-              "// Listen for the clearing of the current output cell\n",
-              "var outputEl = gd.closest('.output');\n",
-              "if (outputEl) {{\n",
-              "    x.observe(outputEl, {childList: true});\n",
-              "}}\n",
-              "\n",
-              "                        })                };                            </script>        </div>\n",
-              "</body>\n",
-              "</html>"
-            ]
-          },
-          "metadata": {}
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 25,
+      "metadata": {
+        "cellView": "form",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 17
+        },
+        "id": "5DiRrG2QGzmp",
+        "outputId": "0948b885-46d4-469c-ae92-61a52de38c4d"
+      },
+      "outputs": [
+        {
+          "data": {
+            "application/javascript": "\n    async function download(id, filename, size) {\n      if (!google.colab.kernel.accessAllowed) {\n        return;\n      }\n      const div = document.createElement('div');\n      const label = document.createElement('label');\n      label.textContent = `Downloading \"${filename}\": `;\n      div.appendChild(label);\n      const progress = document.createElement('progress');\n      progress.max = size;\n      div.appendChild(progress);\n      document.body.appendChild(div);\n\n      const buffers = [];\n      let downloaded = 0;\n\n      const channel = await google.colab.kernel.comms.open(id);\n      // Send a message to notify the kernel that we're ready.\n      channel.send({})\n\n      for await (const message of channel.messages) {\n        // Send a message to notify the kernel that we're ready.\n        channel.send({})\n        if (message.buffers) {\n          for (const buffer of message.buffers) {\n            buffers.push(buffer);\n            downloaded += buffer.byteLength;\n            progress.value = downloaded;\n          }\n        }\n      }\n      const blob = new Blob(buffers, {type: 'application/binary'});\n      const a = document.createElement('a');\n      a.href = window.URL.createObjectURL(blob);\n      a.download = filename;\n      div.appendChild(a);\n      a.click();\n      div.remove();\n    }\n  ",
+            "text/plain": [
+              "<IPython.core.display.Javascript object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        },
+        {
+          "data": {
+            "application/javascript": "download(\"download_e0076c6e-0fa8-4113-8224-0d17289461e1\", \"nise_output-1769013970.zip\", 32868307)",
+            "text/plain": [
+              "<IPython.core.display.Javascript object>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
       "source": [
         "# @title Download Trajectory Results\n",
         "import os\n",
@@ -1033,83 +1048,25 @@
         "\n",
         "  subprocess.run(f'cd /content/nise_trajectory; zip -r {default_zip_output} *', shell=True)\n",
         "  files.download(default_zip_output)\n"
-      ],
-      "metadata": {
-        "cellView": "form",
-        "id": "5DiRrG2QGzmp",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 17
-        },
-        "outputId": "0948b885-46d4-469c-ae92-61a52de38c4d"
-      },
-      "execution_count": 25,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.Javascript object>"
-            ],
-            "application/javascript": [
-              "\n",
-              "    async function download(id, filename, size) {\n",
-              "      if (!google.colab.kernel.accessAllowed) {\n",
-              "        return;\n",
-              "      }\n",
-              "      const div = document.createElement('div');\n",
-              "      const label = document.createElement('label');\n",
-              "      label.textContent = `Downloading \"${filename}\": `;\n",
-              "      div.appendChild(label);\n",
-              "      const progress = document.createElement('progress');\n",
-              "      progress.max = size;\n",
-              "      div.appendChild(progress);\n",
-              "      document.body.appendChild(div);\n",
-              "\n",
-              "      const buffers = [];\n",
-              "      let downloaded = 0;\n",
-              "\n",
-              "      const channel = await google.colab.kernel.comms.open(id);\n",
-              "      // Send a message to notify the kernel that we're ready.\n",
-              "      channel.send({})\n",
-              "\n",
-              "      for await (const message of channel.messages) {\n",
-              "        // Send a message to notify the kernel that we're ready.\n",
-              "        channel.send({})\n",
-              "        if (message.buffers) {\n",
-              "          for (const buffer of message.buffers) {\n",
-              "            buffers.push(buffer);\n",
-              "            downloaded += buffer.byteLength;\n",
-              "            progress.value = downloaded;\n",
-              "          }\n",
-              "        }\n",
-              "      }\n",
-              "      const blob = new Blob(buffers, {type: 'application/binary'});\n",
-              "      const a = document.createElement('a');\n",
-              "      a.href = window.URL.createObjectURL(blob);\n",
-              "      a.download = filename;\n",
-              "      div.appendChild(a);\n",
-              "      a.click();\n",
-              "      div.remove();\n",
-              "    }\n",
-              "  "
-            ]
-          },
-          "metadata": {}
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "text/plain": [
-              "<IPython.core.display.Javascript object>"
-            ],
-            "application/javascript": [
-              "download(\"download_e0076c6e-0fa8-4113-8224-0d17289461e1\", \"nise_output-1769013970.zip\", 32868307)"
-            ]
-          },
-          "metadata": {}
-        }
       ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "authorship_tag": "ABX9TyNQajT6vsVn6b4tVLiQC7jn",
+      "gpuType": "A100",
+      "include_colab_link": true,
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/identify_surface_residues.ipynb
+++ b/identify_surface_residues.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 15,
    "id": "d407f892",
    "metadata": {},
    "outputs": [],
@@ -21,7 +21,15 @@
     "from utils.burial_calc import calc_residue_burial\n",
     "\n",
     "\n",
-    "input_path = Path('./example_pdbs/16_pose26_en_-5p044_no_CG_top1_of_1_n4_00374_looped_master_6_gly_0001_trim_H_98.pdb')"
+    "# input_path = Path('/nfs/polizzi/bfry/programs/NISE/design_campaign_adn/pose_03/input_backbones/seq_0028_model_0.pdb')\n",
+    "# input_path = Path('/nfs/polizzi/bfry/programs/CARPdock/apixaban_ntf2_screen/nise_round1_apixaban_ntf2_top20/seq_0543_model_0_rank_04.pdb')\n",
+    "# input_path = Path('/nfs/polizzi/bfry/programs/CARPdock/apixaban_ntf2_screen/nise_round1_apixaban_ntf2_top20/seq_1073_model_0_rank_05.pdb')\n",
+    "# input_path = Path('/nfs/polizzi/bfry/programs/NISE/design_campaign_exa_ntf2/pose_00/input_backbones/seq_1060_model_0_rank_01.pdb')\n",
+    "# input_path = Path('/nfs/polizzi/bfry/programs/NISE/design_campaign_exa_ntf2/pose_01/input_backbones/seq_1081_model_0_rank_02.pdb')\n",
+    "# input_path = Path('/nfs/polizzi/bfry/programs/NISE/design_campaign_exa_ntf2/pose_02/input_backbones/seq_1157_model_0_rank_03.pdb')\n",
+    "# input_path = Path('/nfs/polizzi/bfry/programs/NISE/design_campaign_apx_ntf2/pose_03/input_backbones/seq_0898_model_0_rank_01.pdb')\n",
+    "# input_path = Path('/nfs/polizzi/bfry/programs/NISE/design_campaign_apx_ntf2/pose_04/input_backbones/seq_0935_model_0_rank_04.pdb')\n",
+    "input_path = Path('/nfs/polizzi/bfry/programs/NISE/design_campaign_exa_ntf2/r2_rf3_pose_02/input_backbones/02_9735_model_0.pdb')"
    ]
   },
   {
@@ -34,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 16,
    "id": "87e17fe9",
    "metadata": {},
    "outputs": [],
@@ -66,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 17,
    "id": "6c11aaa5",
    "metadata": {},
    "outputs": [],
@@ -94,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 18,
    "id": "4683dcb3",
    "metadata": {},
    "outputs": [],
@@ -107,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 19,
    "id": "568abb44",
    "metadata": {},
    "outputs": [],
@@ -127,17 +135,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 20,
    "id": "9a972872",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'resnum 2 or resnum 5 or resnum 6 or resnum 8 or resnum 9 or resnum 12 or resnum 13 or resnum 15 or resnum 16 or resnum 19 or resnum 20 or resnum 22 or resnum 23 or resnum 26 or resnum 27 or resnum 29 or resnum 30 or resnum 33 or resnum 34 or resnum 37 or resnum 38 or resnum 39 or resnum 41 or resnum 42 or resnum 45 or resnum 46 or resnum 48 or resnum 49 or resnum 52 or resnum 53 or resnum 55 or resnum 56 or resnum 59 or resnum 60 or resnum 62 or resnum 63 or resnum 66 or resnum 67 or resnum 69 or resnum 70 or resnum 78 or resnum 79 or resnum 81 or resnum 82 or resnum 84 or resnum 85 or resnum 88 or resnum 89 or resnum 91 or resnum 92 or resnum 95 or resnum 96 or resnum 98 or resnum 99 or resnum 102 or resnum 103 or resnum 106 or resnum 109 or resnum 110 or resnum 115 or resnum 116 or resnum 118 or resnum 119 or resnum 122 or resnum 123 or resnum 125 or resnum 126 or resnum 129 or resnum 130 or resnum 132 or resnum 133 or resnum 136 or resnum 137 or resnum 139 or resnum 140 or resnum 143 or resnum 144 or resnum 146 or resnum 147'"
+       "'resnum 3 or resnum 4 or resnum 5 or resnum 7 or resnum 8 or resnum 11 or resnum 12 or resnum 15 or resnum 18 or resnum 19 or resnum 23 or resnum 24 or resnum 27 or resnum 28 or resnum 32 or resnum 33 or resnum 35 or resnum 37 or resnum 43 or resnum 48 or resnum 49 or resnum 52 or resnum 55 or resnum 56 or resnum 63 or resnum 65 or resnum 66 or resnum 67 or resnum 68 or resnum 70 or resnum 72 or resnum 75 or resnum 77 or resnum 79 or resnum 81 or resnum 83 or resnum 85 or resnum 86 or resnum 89 or resnum 90 or resnum 91 or resnum 92 or resnum 94 or resnum 96 or resnum 98 or resnum 100 or resnum 102 or resnum 105 or resnum 107 or resnum 108 or resnum 110 or resnum 112 or resnum 113 or resnum 114'"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -155,7 +163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 21,
    "id": "df4ad356",
    "metadata": {},
    "outputs": [
@@ -165,7 +173,7 @@
        "'dssp_and_burial_masked.pdb'"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -173,11 +181,27 @@
    "source": [
     "pr.writePDB('dssp_and_burial_masked.pdb', protein)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef585314",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07e567c1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "lasermpnn",
+   "display_name": "lasermpnn2",
    "language": "python",
    "name": "python3"
   },
@@ -191,7 +215,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/run_nise_boltz1x.py
+++ b/run_nise_boltz1x.py
@@ -454,10 +454,16 @@ if __name__ == "__main__":
         'chi_temp': 1e-6, 'seq_min_p': 0.0, 'chi_min_p': 0.0,
         'disable_pbar': True, 'disabled_residues_list': ['X', 'C'], # Disables cysteine sampling by default.
         # ==================================================================================================== 
-        # Optional: Pass a prody selection string of the form ('resnum 1 or resnum 3 or resnum 5...') to 
-        # specify residues over which to constrain the sampling of ALA or GLY residues. 
-        # This string can be generated using './identify_surface_residues.ipynb'
+        # If constrain_ala_gly_sampling_to_exposed_non_secondary_structure is True (recommended), 
+        # the ala_budget and gly_budget parameters are 
+        # used to constrain the sampling of ALA and GLY residues to exposed non-secondary structured residues.
+        # You can override the specific residues with the budget_residue_sele_string parameter (not recommended).
+        # If constrain_ala_gly_sampling_to_exposed_non_secondary_structure is False and budget_residue_sele_string is None,
+        # no constraints are applied to the sampling of ALA and GLY residues.
+        # The reason we suggest doing this is to constrain the generated sequences to the manifold of sequences that are likely to exist in nature 
+        # and not exploiting a propensity of structure prediction networks to predict structure in alanine rich sequences
         # ==================================================================================================== 
+        'constrain_ala_gly_sampling_to_exposed_non_secondary_structure': True,
         'budget_residue_sele_string': None, 
         'ala_budget': 4, 'gly_budget': 0, # May sample up to 4 Ala and 0 Gly over the selected region.
         'disable_charged_fs': True,

--- a/run_nise_boltz2x.py
+++ b/run_nise_boltz2x.py
@@ -559,10 +559,16 @@ if __name__ == "__main__":
         'chi_temp': 1e-6, 'seq_min_p': 0.0, 'chi_min_p': 0.0,
         'disable_pbar': True, 'disabled_residues_list': ['X', 'C'], # Disables cysteine sampling by default.
         # ==================================================================================================== 
-        # Optional: Pass a prody selection string of the form ('resnum 1 or resnum 3 or resnum 5...') to 
-        # specify residues over which to constrain the sampling of ALA or GLY residues. 
-        # This string can be generated using './identify_surface_residues.ipynb'
+        # If constrain_ala_gly_sampling_to_exposed_non_secondary_structure is True (recommended), 
+        # the ala_budget and gly_budget parameters are 
+        # used to constrain the sampling of ALA and GLY residues to exposed non-secondary structured residues.
+        # You can override the specific residues with the budget_residue_sele_string parameter (not recommended).
+        # If constrain_ala_gly_sampling_to_exposed_non_secondary_structure is False and budget_residue_sele_string is None,
+        # no constraints are applied to the sampling of ALA and GLY residues.
+        # The reason we suggest doing this is to constrain the generated sequences to the manifold of sequences that are likely to exist in nature 
+        # and not exploiting a propensity of structure prediction networks to predict structure in alanine rich sequences
         # ==================================================================================================== 
+        'constrain_ala_gly_sampling_to_exposed_non_secondary_structure': True,
         'budget_residue_sele_string': None, 
         'ala_budget': 4, 'gly_budget': 0, # May sample up to 4 Ala and 0 Gly over the selected region if not None.
         'disable_charged_fs': True, # Disables sampling D,E,K,R residues for buried residues around the ligand. 
@@ -570,7 +576,7 @@ if __name__ == "__main__":
 
 
     params = dict(
-        debug = (debug := True),
+        debug = (debug := False),
         use_wandb = (use_wandb := False),
 
         input_dir = Path('./debug/').resolve(),

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ subprocess.check_call(
         "matplotlib",
         "rdkit-to-params",
         "seaborn",
+        "pydssp",
         "jupyter",
         "plotly",
         "pykeops",


### PR DESCRIPTION
This pull request introduces updates to the `identify_surface_residues.ipynb` notebook, modifies the default configuration and documentation for alanine/glycine sampling constraints in `run_nise_boltz1x.py` and `run_nise_boltz2x.py`, updates the submodule commit for `LASErMPNN`, and adds a new dependency to `setup.py`. The changes improve clarity, reproducibility, and the biological relevance of sequence sampling.

**Configuration and documentation enhancements:**

* Improved documentation in `run_nise_boltz1x.py` and `run_nise_boltz2x.py` for alanine/glycine sampling constraints, clarifying the recommended settings and their biological rationale. Enabled `constrain_ala_gly_sampling_to_exposed_non-secondary_structure` by default and set `debug` to `False` in `run_nise_boltz2x.py`. [[1]](diffhunk://#diff-a5bbc315f19ea1675196fc02e3242cbdcacc2deecd759e91d16ecac779938d34L457-R466) [[2]](diffhunk://#diff-b526f93a848b696443dd844f0ac6a988fb031d4cae140647952ee98c5632b114L562-R579)

**Dependency updates:**

* Added `pydssp` as a required dependency in `setup.py` to support secondary structure calculations.

**Submodule update:**

* Updated the `LASErMPNN` submodule to a new commit, potentially bringing in upstream improvements or bug fixes.